### PR TITLE
Clear ResourceList before filling it

### DIFF
--- a/src/AS_DCP_TimedText.cpp
+++ b/src/AS_DCP_TimedText.cpp
@@ -160,6 +160,7 @@ ASDCP::TimedText::MXFReader::h__Reader::MD_to_TimedText_TDesc(TimedText::TimedTe
   memcpy(TDesc.AssetID, TDescObj->ResourceID.Value(), UUIDlen);
   TDesc.NamespaceName = TDescObj->NamespaceURI;
   TDesc.EncodingName = TDescObj->UCSEncoding;
+  TDesc.ResourceList.clear();
 
   Array<UUID>::const_iterator sdi = TDescObj->SubDescriptors.begin();
   TimedTextResourceSubDescriptor* DescObject = 0;


### PR DESCRIPTION
If the same TimedText MXFReader is opened more than once the descriptor's resource list isn't cleared before it is populated.  This causes duplicate resources within the list.

Does anyone know if the SMPTE specs state that a unique resource can only appear once in the resource list?  We couldn't find anything that said either way.