### PR TITLE
added greater-than operator to Kumu::Identifier

### DIFF
--- a/src/KM_util.h
+++ b/src/KM_util.h
@@ -303,6 +303,18 @@ namespace Kumu
 	return false;
       }
 
+      inline bool operator>(const Identifier& rhs) const {
+	ui32_t test_size = xmin(rhs.Size(), SIZE);
+
+	for ( ui32_t i = 0; i < test_size; i++ )
+	  {
+	    if ( m_Value[i] != rhs.m_Value[i] )
+	      return m_Value[i] > rhs.m_Value[i];
+	  }
+	
+	return false;
+      }
+
       inline bool operator==(const Identifier& rhs) const {
 	if ( rhs.Size() != SIZE ) return false;
 	return ( memcmp(m_Value, rhs.m_Value, SIZE) == 0 );


### PR DESCRIPTION
I needed to perform a greater-than comparison on identifiers. This implementation mirrors that of the less-than operator.
