### PR TITLE
Fix == operator in jp2k seq parser

### DIFF
--- a/src/JP2K_Sequence_Parser.cpp
+++ b/src/JP2K_Sequence_Parser.cpp
@@ -229,7 +229,7 @@ operator==(const ASDCP::JP2K::CodingStyleDefault_t& lhs, const ASDCP::JP2K::Codi
 
   for ( ui32_t i = 0; i < sizeof(ui16_t); i++ )
     {
-      if ( lhs.SGcod.NumberOfLayers[i] != lhs.SGcod.NumberOfLayers[i]  )
+      if ( lhs.SGcod.NumberOfLayers[i] != rhs.SGcod.NumberOfLayers[i]  )
 	return false;
     }
 


### PR DESCRIPTION
# What this PR does
Fixes typo in == operator of JP2K sequence parser 

## Explanation
Previously that condition was always `false`