### PR TITLE
Fix Object ref not being written

### DIFF
--- a/src/MXF.h
+++ b/src/MXF.h
@@ -253,7 +253,7 @@ namespace ASDCP
 	  }
 	  bool operator==(const PropertyType& rhs) const { return this->m_property == rhs; }
 	  bool operator==(const optional_property<PropertyType>& rhs) const { return this->m_property == rhs.m_property; }
-	  operator PropertyType&() { return this->m_property; }
+	  operator const PropertyType&() const { return this->m_property; }
 	  void set(const PropertyType& rhs) { this->m_property = rhs; this->m_has_value = true; }
 	  void set_has_value(bool has_value = true) { this->m_has_value = has_value; }
 	  void reset(const PropertyType& rhs) { this->m_has_value = false; }

--- a/src/h__Writer.cpp
+++ b/src/h__Writer.cpp
@@ -180,7 +180,8 @@ ASDCP::AddDmsTrackGenericPartUtf8Text(Kumu::FileWriter& file_writer, MXF::OP1aHe
   assert(dmf_obj);
   header_part.AddChildObject(dmf_obj);
   Segment->DMFramework = dmf_obj->InstanceUID;
-  GenRandomValue(dmf_obj->ObjectRef);
+  GenRandomValue(dmf_obj->ObjectRef.get());
+  dmf_obj->ObjectRef.set_has_value();
 
   // Create a new SID on the RIP, located at the current file position
   ui32_t max_sid = 0;


### PR DESCRIPTION
This prevented GenericStreamTextBasedSet from being correctly linked to TextBasedDMFramework