### PR TITLE
Fix typo.

### DIFF
--- a/src/AS_02.h
+++ b/src/AS_02.h
@@ -530,7 +530,7 @@ namespace AS_02
       // error occurs.
       Result_t WriteFrame(const ASDCP::FrameBuffer&, ASDCP::AESEncContext* = 0, ASDCP::HMACContext* = 0);
 
-      // Writes an XML text document to the MXF file as per RP 2067. If the
+      // Writes an XML text document to the MXF file as per RP 2057. If the
       // optional AESEncContext argument is present, the document is encrypted
       // prior to writing. Fails if the file is not open, is finalized, or an
       // operating system error occurs.


### PR DESCRIPTION
I believe this actually references SMPTE RP 2057 "Text-Based Metadata Carriage in MXF" (implemented as part of commit f4061a21fffad4fdf8dbb2f193f0f0960b25421c).