### PR TITLE
Improve error diagnostic in timed text parser

### DIFF
--- a/src/TimedText_Parser.cpp
+++ b/src/TimedText_Parser.cpp
@@ -396,7 +396,6 @@ ASDCP::TimedText::DCSubtitleParser::h__SubtitleParser::ReadAncillaryResource(con
     {
       DefaultLogSink().Error("Resource not found: %s (%s)\n", TmpID.EncodeHex(buf, 64), resourceType.c_str());
     }
-    
 
   return result;
 }

--- a/src/TimedText_Parser.cpp
+++ b/src/TimedText_Parser.cpp
@@ -380,17 +380,23 @@ ASDCP::TimedText::DCSubtitleParser::h__SubtitleParser::ReadAncillaryResource(con
 
   Result_t result = Resolver.ResolveRID(uuid, FrameBuf);
 
+  std::string resourceType;
+  if ( (*rmi).second == MT_PNG )
+    resourceType = "image/png";
+  else if ( (*rmi).second == MT_OPENTYPE )
+    resourceType = "application/x-font-opentype";
+  else
+    resourceType = "application/octet-stream";
+
   if ( KM_SUCCESS(result) )
     {
-      if ( (*rmi).second == MT_PNG )
-	FrameBuf.MIMEType("image/png");
-	      
-      else if ( (*rmi).second == MT_OPENTYPE )
-	FrameBuf.MIMEType("application/x-font-opentype");
-
-      else
-	FrameBuf.MIMEType("application/octet-stream");
+      FrameBuf.MIMEType(resourceType);
     }
+  else
+    {
+      DefaultLogSink().Error("Resource not found: %s (%s)\n", TmpID.EncodeHex(buf, 64), resourceType.c_str());
+    }
+    
 
   return result;
 }


### PR DESCRIPTION
This is an attempt to have a more helpful error message when trying to wrap an SMPTE subtitle track while missing ancillary resources (typically the font file).

In this scenario, asdcp-wrap will still produce a malformed MXF that is identified as AS-02 by asdcp-info, that can be misleading while debugging.