### PR TITLE
add API call to expose the MIC key from an encrypted MXF

### DIFF
--- a/src/AS_DCP.h
+++ b/src/AS_DCP.h
@@ -507,6 +507,11 @@ namespace ASDCP {
       // point to a readable area of memory that is at least HMAC_SIZE bytes in length.
       // Returns error if the buf argument is NULL or if the values do ot match.
       Result_t TestHMACValue(const byte_t* buf) const;
+
+      // Writes MIC key to given buffer. buf must point to a writable area of
+      // memory that is at least KeyLen bytes in length. Returns error if the
+      // buf argument is NULL.
+      Result_t GetMICKey(byte_t* buf) const;
     };
 
   //---------------------------------------------------------------------------------

--- a/src/AS_DCP_AES.cpp
+++ b/src/AS_DCP_AES.cpp
@@ -349,6 +349,13 @@ public:
     SHA1_Final(m_SHAValue, &SHA);
     m_Final = true;
   }
+
+  //
+  void
+  GetMICKey(byte_t* buf) const
+  {
+    memcpy(buf, m_key, KeyLen);
+  }
 };
 
 
@@ -441,6 +448,20 @@ HMACContext::TestHMACValue(const byte_t* buf) const
     return RESULT_INIT;
   
   return ( memcmp(buf, m_Context->m_SHAValue, HMAC_SIZE) == 0 ) ? RESULT_OK : RESULT_HMACFAIL;
+}
+
+
+//
+Result_t
+HMACContext::GetMICKey(byte_t* buf) const
+{
+  KM_TEST_NULL_L(buf);
+
+  if ( m_Context.empty() )
+    return RESULT_INIT;
+
+  m_Context->GetMICKey(buf);
+  return RESULT_OK;
 }
 
 


### PR DESCRIPTION
This adds an API call to expose the MIC key from an encrypted MXF. This is useful for higher-level applications that desire this value for KDM construction.
