### PR TITLE
README - adds make install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ autoreconf -if
 ./configure --enable-freedist --enable-as-02
 make
 make dist
+make install
 ```
 
 ## Libraries


### PR DESCRIPTION
Hi - I don't know much about building but I couldn't get the actual tools until I used `make install`, so figured I'd add it to the steps here.
I'm a bit more used to building things without autotools and such, like ffmpeg - and in this case, the binaries appear in the build directory without having to run make install, which usually seems to just make symlinks into the relevant `bin`