### PR TITLE
Customize namespace names

### DIFF
--- a/README.cmake
+++ b/README.cmake
@@ -3,6 +3,13 @@ As an alternative to configure (autotools), cmake build system files are provide
 In order to use them, you will need to install Cmake binaries on your system, or build Cmake from source.
 Note: Cmake 2.8.12 or higher is required.
 
+**Options**
+The following options can be defined on the cmake command line with the -D switch:
+
+KUMU_NAMESPACE - Sets the C++ namespace for the Kumu library (default "Kumu")
+ASDCP_NAMESPACE - Sets the C++ namespace for the ASDCP library (default "ASDCP")
+AS_02_NAMESPACE - Sets the C++ namespace for the AS-02 library (default "AS_02")
+
 **Configuration**
 Linux / MacOS:
 $ mkdir build

--- a/README.cmake
+++ b/README.cmake
@@ -6,6 +6,10 @@ Note: Cmake 2.8.12 or higher is required.
 **Options**
 The following options can be defined on the cmake command line with the -D switch:
 
+Use these definitions to override the default library namespaces.
+This can be useful when including asdcplib's objects in another static library in order to avoid
+symbol clashes in applications that link to both asdcplib and the library including asdcplib.
+
 KUMU_NAMESPACE - Sets the C++ namespace for the Kumu library (default "Kumu")
 ASDCP_NAMESPACE - Sets the C++ namespace for the ASDCP library (default "ASDCP")
 AS_02_NAMESPACE - Sets the C++ namespace for the AS-02 library (default "AS_02")

--- a/src/ACES.h
+++ b/src/ACES.h
@@ -36,8 +36,8 @@ This module implements ACES header parser.
 #include "AS_02_ACES.h"
 
 
-namespace AS_02
-{
+AS_02_NAMESPACE_BEGIN
+
 
 namespace ACES
 {
@@ -132,6 +132,6 @@ public:
 
 } // namespace ACES
 
-} // namespace AS_02
+AS_02_NAMESPACE_END
 
 #endif // ACES_h__

--- a/src/AS_02.h
+++ b/src/AS_02.h
@@ -56,11 +56,12 @@ NOTE: ciphertext support for clip-wrapped PCM is not yet complete.
 #ifndef _AS_02_H_
 #define _AS_02_H_
 
+#include "AS_02_namespace.h"
 #include "Metadata.h"
 
 
-namespace AS_02
-{
+AS_02_NAMESPACE_BEGIN
+
   using Kumu::Result_t;
 
   KM_DECLARE_RESULT(AS02_FORMAT,        -116, "The file format is not proper OP-1a/AS-02.");
@@ -591,7 +592,7 @@ namespace AS_02
     
   }
 
-} // namespace AS_02
+AS_02_NAMESPACE_END
 
 #endif // _AS_02_H_
 

--- a/src/AS_02_ACES.h
+++ b/src/AS_02_ACES.h
@@ -58,8 +58,8 @@ typedef ui16_t      real16_t;
 typedef float       real32_t;
 typedef double      real64_t;
 
-namespace AS_02
-{
+AS_02_NAMESPACE_BEGIN
+
 
 using Kumu::Result_t;
 using Kumu::RESULT_FALSE;
@@ -491,6 +491,6 @@ public:
 };
 } // namespace ACES
 
-} // namespace AS_02
+AS_02_NAMESPACE_END
 
 #endif // AS_02_ACES_h__

--- a/src/AS_02_IAB.cpp
+++ b/src/AS_02_IAB.cpp
@@ -34,7 +34,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iomanip>
 #include <stdexcept>
 
-namespace Kumu {
+KUMU_NAMESPACE_BEGIN
   class RuntimeError : public std::runtime_error {
     Kumu::Result_t m_Result;
     RuntimeError();
@@ -43,7 +43,7 @@ namespace Kumu {
     Kumu::Result_t GetResult() { return this->m_Result; }
     ~RuntimeError() throw() {}
   };
-}
+KUMU_NAMESPACE_END
 
 //------------------------------------------------------------------------------------------
 

--- a/src/AS_02_IAB.h
+++ b/src/AS_02_IAB.h
@@ -40,7 +40,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "AS_02_internal.h"
 #include "Metadata.h"
 
-namespace AS_02 {
+AS_02_NAMESPACE_BEGIN
 
   namespace IAB {
 
@@ -234,6 +234,6 @@ namespace AS_02 {
 
   } //namespace IAB
 
-} // namespace AS_02
+AS_02_NAMESPACE_END
 
 #endif // AS_02_IAB_h__

--- a/src/AS_02_PHDR.h
+++ b/src/AS_02_PHDR.h
@@ -37,8 +37,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "AS_02.h"
 
-namespace AS_02
-{
+AS_02_NAMESPACE_BEGIN
+
 
   namespace PHDR
   { 
@@ -182,7 +182,7 @@ namespace AS_02
     
   } // end namespace PHDR
 
-} // end namespace AS_02
+AS_02_NAMESPACE_END
 
 #endif // _AS_02_PHDR_H_
 

--- a/src/AS_02_internal.h
+++ b/src/AS_02_internal.h
@@ -34,11 +34,14 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _AS_02_INTERNAL_H_
 #define _AS_02_INTERNAL_H_
 
+#include "AS_02_namespace.h"
 #include "KM_log.h"
 #include "AS_DCP_internal.h"
 #include "AS_02.h"
 
 using Kumu::DefaultLogSink;
+
+AS_02_NAMESPACE_BEGIN
 
 #ifdef DEFAULT_02_MD_DECL
 AS_02::MXF::AS02IndexReader *g_AS02IndexReader;
@@ -47,8 +50,6 @@ extern AS_02::MXF::AS02IndexReader *g_AS02IndexReader;
 #endif
 
 
-namespace AS_02
-{
 
   void default_md_object_init();
 
@@ -333,7 +334,7 @@ namespace AS_02
       Result_t FinalizeClip(ui32_t bytes_per_frame);
     };
 
-} // namespace AS_02
+AS_02_NAMESPACE_END
 
 #endif // _AS_02_INTERNAL_H_
 

--- a/src/AS_02_namespace.h.template
+++ b/src/AS_02_namespace.h.template
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2014, John Hurst
+Copyright (c) 2003-2020, John Hurst
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/AS_02_namespace.h.template
+++ b/src/AS_02_namespace.h.template
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2013-2013, John Hurst
+Copyright (c) 2003-2014, John Hurst
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,20 +24,24 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-/*! \file    CRC16.h
-    \version $Id$
-    \brief   Declaration of a CRC function
-*/
 
-#ifndef _CRC_16_H_
-#define _CRC_16_H_
+#ifndef _AS_02_NAMESPACE_H_
+#define _AS_02_NAMESPACE_H_
 
-#include "AS_DCP_namespace.h"
+#cmakedefine AS_02_NAMESPACE @AS_02_NAMESPACE@
 
-ASDCP_NAMESPACE_BEGIN
+#ifndef AS_02_NAMESPACE
+	#define AS_02_NAMESPACE AS_02
+	#define AS_02_NAMESPACE_BEGIN namespace AS_02 {
+	#define AS_02_NAMESPACE_END  }
+	#define AS_02_NAMESPACE_USE using namespace AS_02;
+#else
+	#define AS_02_NAMESPACE_BEGIN namespace @AS_02_NAMESPACE@ {
+	#define AS_02_NAMESPACE_END  }
+	#define AS_02_NAMESPACE_USE using namespace @AS_02_NAMESPACE@;
 
-unsigned short CRC16(const void *pData, int ilength);
-
-ASDCP_NAMESPACE_END
-
+	namespace @AS_02_NAMESPACE@ { }
+	namespace AS_02 = @AS_02_NAMESPACE@;
 #endif
+
+#endif //_AS_02_NAMESPACE_H_

--- a/src/AS_02_namespace.h.template
+++ b/src/AS_02_namespace.h.template
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2020, John Hurst
+Copyright (c) 2020, Dolby Laboratories
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/AS_DCP.h
+++ b/src/AS_DCP.h
@@ -84,6 +84,8 @@ This project depends upon the following libraries:
 #ifndef _AS_DCP_H_
 #define _AS_DCP_H_
 
+#include "AS_DCP_namespace.h"
+
 #include <KM_error.h>
 #include <KM_fileio.h>
 #include <stdio.h>
@@ -145,7 +147,7 @@ typedef unsigned int   ui32_t;
 //--------------------------------------------------------------------------------
 // All library components are defined in the namespace ASDCP
 //
-namespace ASDCP {
+ASDCP_NAMESPACE_BEGIN
   //
   // The version number declaration and explanation have moved to ../configure.ac
   const char* Version();
@@ -1957,7 +1959,7 @@ namespace ASDCP {
 
 
 
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 
 #endif // _AS_DCP_H_

--- a/src/AS_DCP_ATMOS.cpp
+++ b/src/AS_DCP_ATMOS.cpp
@@ -35,8 +35,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "AS_DCP.h"
 #include "AS_DCP_internal.h"
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
 namespace ATMOS
 {
   static std::string ATMOS_PACKAGE_LABEL = "File Package: SMPTE-GC frame wrapping of Dolby ATMOS data";
@@ -44,7 +44,7 @@ namespace ATMOS
   static byte_t ATMOS_ESSENCE_CODING[SMPTE_UL_LENGTH] = { 0x06, 0x0e, 0x2b, 0x34, 0x04, 0x01, 0x01, 0x05,
                                                           0x0e, 0x09, 0x06, 0x04, 0x00, 0x00, 0x00, 0x00 };
 } // namespace ATMOS
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 //
 std::ostream&

--- a/src/AS_DCP_DCData.cpp
+++ b/src/AS_DCP_DCData.cpp
@@ -34,14 +34,14 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "AS_DCP.h"
 #include "AS_DCP_internal.h"
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
   namespace DCData
   {
     static std::string DC_DATA_PACKAGE_LABEL = "File Package: SMPTE-GC frame wrapping of D-Cinema Generic data";
     static std::string DC_DATA_DEF_LABEL = "D-Cinema Generic Data Track";
   } // namespace DCData
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 //
 std::ostream&

--- a/src/AS_DCP_DCData_internal.h
+++ b/src/AS_DCP_DCData_internal.h
@@ -36,8 +36,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "AS_DCP_internal.h"
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
 
 namespace MXF
 {
@@ -89,6 +89,6 @@ namespace DCData
 
 
 } // namespace DCData
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 #endif // _AS_DCP_DCDATA_INTERNAL_H_

--- a/src/AS_DCP_internal.h
+++ b/src/AS_DCP_internal.h
@@ -50,6 +50,7 @@ using namespace ASDCP::MXF;
 // uncomment to remove MXFGCGenericEssenceMultipleMappings from your AS-02 files
 // #define ASDCP_GCMULTI_PATCH
 
+ASDCP_NAMESPACE_BEGIN
 
 #ifdef DEFAULT_MD_DECL
 ASDCP::MXF::OP1aHeader *g_OP1aHeader;
@@ -62,8 +63,7 @@ extern MXF::RIP *g_RIP;
 #endif
 
 
-namespace ASDCP
-{
+
 
   //
   static std::vector<int>
@@ -964,7 +964,7 @@ namespace ASDCP
     };
 
 
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 #endif // _AS_DCP_INTERNAL_H_
 

--- a/src/AS_DCP_namespace.h.template
+++ b/src/AS_DCP_namespace.h.template
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2014, John Hurst
+Copyright (c) 2003-2020, John Hurst
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/AS_DCP_namespace.h.template
+++ b/src/AS_DCP_namespace.h.template
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2020, John Hurst
+Copyright (c) 2020, Dolby Laboratories
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/AS_DCP_namespace.h.template
+++ b/src/AS_DCP_namespace.h.template
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2013-2013, John Hurst
+Copyright (c) 2003-2014, John Hurst
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,20 +24,24 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-/*! \file    CRC16.h
-    \version $Id$
-    \brief   Declaration of a CRC function
-*/
 
-#ifndef _CRC_16_H_
-#define _CRC_16_H_
+#ifndef _ASDCP_NAMESPACE_H_
+#define _ASDCP_NAMESPACE_H_
 
-#include "AS_DCP_namespace.h"
+#cmakedefine ASDCP_NAMESPACE @ASDCP_NAMESPACE@
 
-ASDCP_NAMESPACE_BEGIN
+#ifndef ASDCP_NAMESPACE
+	#define ASDCP_NAMESPACE ASDCP
+	#define ASDCP_NAMESPACE_BEGIN namespace ASDCP {
+	#define ASDCP_NAMESPACE_END  }
+	#define ASDCP_NAMESPACE_USE using namespace ASDCP;
+#else
+	#define ASDCP_NAMESPACE_BEGIN namespace @ASDCP_NAMESPACE@ {
+	#define ASDCP_NAMESPACE_END  }
+	#define ASDCP_NAMESPACE_USE using namespace @ASDCP_NAMESPACE@;
 
-unsigned short CRC16(const void *pData, int ilength);
-
-ASDCP_NAMESPACE_END
-
+	namespace @ASDCP_NAMESPACE@ { }
+	namespace ASDCP = @ASDCP_NAMESPACE@;
 #endif
+
+#endif //ASDCP_NAMESPACE

--- a/src/AtmosSyncChannel_Generator.h
+++ b/src/AtmosSyncChannel_Generator.h
@@ -39,8 +39,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define INT24_MAX 8388607.0
 #define INT24_MIN -8388608.0
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
     namespace ATMOS
     {
         static const ui32_t SYNC_CHANNEL = 14;
@@ -142,7 +142,7 @@ namespace ASDCP
         };
 
     } // namespace PCM
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 #endif // _ATMOSSYNCCHANNEL_GENERATOR_H_
 

--- a/src/AtmosSyncChannel_Mixer.h
+++ b/src/AtmosSyncChannel_Mixer.h
@@ -37,8 +37,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <PCMDataProviders.h>
 #include <vector>
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
 
   //
   class AtmosSyncChannelMixer
@@ -85,7 +85,7 @@ namespace ASDCP
       Result_t Reset();
       Result_t ReadFrame(PCM::FrameBuffer& OutFB);
     };
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 #endif // _ATMOSSYNCCHANNEL_MIXER_H_
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,7 @@ set(asdcp_src MPEG2_Parser.cpp MPEG.cpp JP2K_Codestream_Parser.cpp JP2K_Sequence
 )
 
 # header for deployment (install target)
-set(asdcp_deploy_header AS_DCP.h PCMParserList.h AS_DCP_internal.h KM_error.h KM_fileio.h KM_util.h KM_memio.h KM_tai.h KM_platform.h KM_log.h KM_mutex.h dirent_win.h ${CMAKE_CURRENT_BINARY_DIR}/KM_namespace.h ${CMAKE_CURRENT_BINARY_DIR}/AS_DCP_namespace.)
+set(asdcp_deploy_header AS_DCP.h PCMParserList.h AS_DCP_internal.h KM_error.h KM_fileio.h KM_util.h KM_memio.h KM_tai.h KM_platform.h KM_log.h KM_mutex.h dirent_win.h ${CMAKE_CURRENT_BINARY_DIR}/KM_namespace.h ${CMAKE_CURRENT_BINARY_DIR}/AS_DCP_namespace.h)
 
 # header
 set(asdcp_src ${asdcp_src} Wav.h WavFileWriter.h MXF.h Metadata.h JP2K.h AS_DCP.h AS_DCP_internal.h KLV.h MPEG.h MXFTypes.h MDD.h
@@ -49,7 +49,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/AS_02_namespace.h.template ${CMAKE_CU
 set(as02_src h__02_Reader.cpp h__02_Writer.cpp AS_02_ISXD.cpp AS_02_JP2K.cpp AS_02_PCM.cpp ST2052_TextParser.cpp AS_02_TimedText.cpp AS_02_ACES.cpp ACES_Codestream_Parser.cpp ACES_Sequence_Parser.cpp ACES.cpp AS_02_IAB.cpp)
 
 # header for deployment (install target)
-set(as02_deploy_header AS_02.h Metadata.h MXF.h MXFTypes.h KLV.h MDD.h AS_02_ACES.h ACES.h AS_02_IAB.h AS_02_internal.h  ${CMAKE_CURRENT_BINARY_DIR}/AS_02_namespace.)
+set(as02_deploy_header AS_02.h Metadata.h MXF.h MXFTypes.h KLV.h MDD.h AS_02_ACES.h ACES.h AS_02_IAB.h AS_02_internal.h  ${CMAKE_CURRENT_BINARY_DIR}/AS_02_namespace.h)
 
 # header
 set(as02_src ${as02_src} AS_02.h AS_02_internal.h AS_02_ACES.h ACES.h AS_02_IAB.h)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,9 @@ if(NOT WIN32)
 endif(NOT WIN32)
 
 # ----------libkumu----------
+# namespace macros - define KUMU_NAMESPACE to override default 'Kumu'
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/KM_namespace.h.template ${CMAKE_CURRENT_BINARY_DIR}/KM_namespace.h @ONLY)
+
 # source
 set(kumu_src KM_fileio.cpp KM_log.cpp KM_prng.cpp KM_util.cpp KM_xml.cpp KM_tai.cpp)
 
@@ -18,16 +21,19 @@ set(kumu_src KM_fileio.cpp KM_log.cpp KM_prng.cpp KM_util.cpp KM_xml.cpp KM_tai.
 set(kumu_src ${kumu_src} KM_fileio.h KM_log.h KM_prng.h KM_util.h KM_xml.h KM_tai.h KM_error.h KM_memio.h KM_mutex.h KM_platform.h dirent_win.h)
 
 # ----------libasdcp----------
+# namespace macros - define ASDCP_NAMESPACE to override default 'ASDCP'
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/AS_DCP_namespace.h.template ${CMAKE_CURRENT_BINARY_DIR}/AS_DCP_namespace.h @ONLY)
+
 # source
 set(asdcp_src MPEG2_Parser.cpp MPEG.cpp JP2K_Codestream_Parser.cpp JP2K_Sequence_Parser.cpp JP2K.cpp PCM_Parser.cpp Wav.cpp 
 	TimedText_Parser.cpp KLV.cpp Dict.cpp MXFTypes.cpp MXF.cpp Index.cpp Metadata.cpp AS_DCP.cpp AS_DCP_MXF.cpp AS_DCP_AES.cpp
 	h__Reader.cpp h__Writer.cpp AS_DCP_MPEG2.cpp AS_DCP_JP2K.cpp AS_DCP_PCM.cpp AS_DCP_TimedText.cpp PCMParserList.cpp MDD.cpp
 	AS_DCP_ATMOS.cpp AS_DCP_DCData.cpp DCData_ByteStream_Parser.cpp DCData_Sequence_Parser.cpp AtmosSyncChannel_Generator.cpp
-	AtmosSyncChannel_Mixer.cpp PCMDataProviders.cpp SyncEncoder.c CRC16.c UUIDInformation.c
+	AtmosSyncChannel_Mixer.cpp PCMDataProviders.cpp SyncEncoder.cpp CRC16.cpp UUIDInformation.cpp
 )
 
 # header for deployment (install target)
-set(asdcp_deploy_header AS_DCP.h PCMParserList.h AS_DCP_internal.h KM_error.h KM_fileio.h KM_util.h KM_memio.h KM_tai.h KM_platform.h KM_log.h KM_mutex.h dirent_win.h)
+set(asdcp_deploy_header AS_DCP.h PCMParserList.h AS_DCP_internal.h KM_error.h KM_fileio.h KM_util.h KM_memio.h KM_tai.h KM_platform.h KM_log.h KM_mutex.h dirent_win.h ${CMAKE_CURRENT_BINARY_DIR}/KM_namespace.h ${CMAKE_CURRENT_BINARY_DIR}/AS_DCP_namespace.)
 
 # header
 set(asdcp_src ${asdcp_src} Wav.h WavFileWriter.h MXF.h Metadata.h JP2K.h AS_DCP.h AS_DCP_internal.h KLV.h MPEG.h MXFTypes.h MDD.h
@@ -36,17 +42,21 @@ set(asdcp_src ${asdcp_src} Wav.h WavFileWriter.h MXF.h Metadata.h JP2K.h AS_DCP.
 )
 
 # ----------as02----------
+# namespace macros - define AS_02_NAMESPACE to override default 'AS_02'
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/AS_02_namespace.h.template ${CMAKE_CURRENT_BINARY_DIR}/AS_02_namespace.h @ONLY)
+
 # source
 set(as02_src h__02_Reader.cpp h__02_Writer.cpp AS_02_ISXD.cpp AS_02_JP2K.cpp AS_02_PCM.cpp ST2052_TextParser.cpp AS_02_TimedText.cpp AS_02_ACES.cpp ACES_Codestream_Parser.cpp ACES_Sequence_Parser.cpp ACES.cpp AS_02_IAB.cpp)
 
 # header for deployment (install target)
-set(as02_deploy_header AS_02.h Metadata.h MXF.h MXFTypes.h KLV.h MDD.h AS_02_ACES.h ACES.h AS_02_IAB.h AS_02_internal.h)
+set(as02_deploy_header AS_02.h Metadata.h MXF.h MXFTypes.h KLV.h MDD.h AS_02_ACES.h ACES.h AS_02_IAB.h AS_02_internal.h  ${CMAKE_CURRENT_BINARY_DIR}/AS_02_namespace.)
 
 # header
 set(as02_src ${as02_src} AS_02.h AS_02_internal.h AS_02_ACES.h ACES.h AS_02_IAB.h)
 
 
 include_directories("${PROJECT_SOURCE_DIR}/src" "${OpenSSLLib_include_DIR}" "${XercescppLib_include_DIR}")
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 add_definitions(/DPACKAGE_VERSION=\"${VERSION_STRING}\" /DHAVE_XERCES_C=1)
 if(WIN32)

--- a/src/CRC16.cpp
+++ b/src/CRC16.cpp
@@ -66,7 +66,7 @@ static const unsigned short g_aushCRC16tab[256]= {
 	0x6e17,0x7e36,0x4e55,0x5e74,0x2e93,0x3eb2,0x0ed1,0x1ef0
 };
 
-unsigned short CRC16(const void *pData, int ilength)
+unsigned short ASDCP::CRC16(const void *pData, int ilength)
 {
 	int n;
 	unsigned short ushCRC;

--- a/src/DCData_Sequence_Parser.cpp
+++ b/src/DCData_Sequence_Parser.cpp
@@ -41,13 +41,13 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using ASDCP::Result_t;
 
 //------------------------------------------------------------------------------------------
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
 namespace DCData
 {
 class FileList;
 } // namespace DCData
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 
 class ASDCP::DCData::FileList : public std::list<std::string>

--- a/src/JP2K.h
+++ b/src/JP2K.h
@@ -41,8 +41,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <AS_DCP.h>
 #include <assert.h>
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
 namespace JP2K
 {
   const byte_t Magic[] = {0xff, 0x4f, 0xff};
@@ -308,7 +308,7 @@ namespace JP2K
       };
     } // namespace Accessor
 } // namespace JP2K
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 #endif // _JP2K_H_
 

--- a/src/KLV.h
+++ b/src/KLV.h
@@ -39,8 +39,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <map>
 
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
   const ui32_t MXF_BER_LENGTH = 4;
   const ui32_t MXF_TAG_LENGTH = 2;
   const ui32_t SMPTE_UL_LENGTH = 16;
@@ -254,7 +254,7 @@ inline const char* ui64sz(ui64_t i, char* buf)
       virtual Result_t WriteKLToFile(Kumu::FileWriter& Writer, const UL& label, ui32_t length);
     };
 
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 #endif // _KLV_H_
 

--- a/src/KM_error.h
+++ b/src/KM_error.h
@@ -34,12 +34,14 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _KM_ERROR_H_
 #define _KM_ERROR_H_
 
+#include <KM_namespace.h>
+
 #include <string>
 
 #define KM_DECLARE_RESULT(sym, i, l) const Result_t RESULT_##sym = Result_t(i, #sym, l);
 
-namespace Kumu
-{
+KUMU_NAMESPACE_BEGIN
+
   // Result code container. Both a signed integer and a text string are stored in the object.
   // When defining your own codes your choice of integer values is mostly unconstrained, but pay
   // attention to the numbering in the other libraries that use Kumu. Values between -99 and 99
@@ -113,8 +115,7 @@ namespace Kumu
   KM_DECLARE_RESULT(DIR_CREATE, -21,  "Unable to create directory.");
   KM_DECLARE_RESULT(NOT_EMPTY,  -22,  "Unable to delete non-empty directory.");
   // 23-100 are reserved
- 
-} // namespace Kumu
+KUMU_NAMESPACE_END
 
 //--------------------------------------------------------------------------------
 // convenience macros
@@ -158,8 +159,8 @@ namespace Kumu
 
 
 
-namespace Kumu
-{
+KUMU_NAMESPACE_BEGIN
+
   // simple tracing mechanism
   class DTrace_t
   {
@@ -176,7 +177,7 @@ namespace Kumu
     DTrace_t(const char* Label, Result_t* Watch, int Line, const char* File);
     ~DTrace_t();
   };
-}
+KUMU_NAMESPACE_END
 
 #ifdef KM_TRACE
 #define WDTRACE(l) DTrace_t __wl__Trace__((l), 0, __LINE__, __FILE__)

--- a/src/KM_fileio.h
+++ b/src/KM_fileio.h
@@ -50,8 +50,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
-namespace Kumu
-{
+KUMU_NAMESPACE_BEGIN
+
   //
   class DirScanner
     {
@@ -378,7 +378,7 @@ namespace Kumu
   Result_t DeleteFile(const std::string& filename);
   Result_t DeletePath(const std::string& pathname);
 
-} // namespace Kumu
+KUMU_NAMESPACE_END
 
 
 #endif // _KM_FILEIO_H_

--- a/src/KM_log.h
+++ b/src/KM_log.h
@@ -66,8 +66,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 
-namespace Kumu
-{
+KUMU_NAMESPACE_BEGIN
+
   // no log message will exceed this length
   const ui32_t MaxLogLength = 512;
 
@@ -319,7 +319,7 @@ namespace Kumu
 #endif
 
 
-} // namespace Kumu
+KUMU_NAMESPACE_END
 
 #endif // _KM_LOG_H_
 

--- a/src/KM_memio.h
+++ b/src/KM_memio.h
@@ -36,8 +36,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <cstring>
 
-namespace Kumu
-{
+KUMU_NAMESPACE_BEGIN
+
   class ByteString;
 
   //
@@ -245,7 +245,7 @@ namespace Kumu
   }
 
 
-} // namespace Kumu
+KUMU_NAMESPACE_END
 
 #endif // _KM_MEMIO_H_
 

--- a/src/KM_mutex.h
+++ b/src/KM_mutex.h
@@ -38,8 +38,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # include <pthread.h>
 #endif
 
-namespace Kumu
-{
+KUMU_NAMESPACE_BEGIN
+
 #ifdef KM_WIN32
   class Mutex
     {
@@ -80,7 +80,7 @@ namespace Kumu
       ~AutoMutex() { m_Mutex.Unlock(); }
     };
 
-} // namespace Kumu
+KUMU_NAMESPACE_END
 
 #endif // _KM_MUTEX_H_
 

--- a/src/KM_namespace.h.template
+++ b/src/KM_namespace.h.template
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2014, John Hurst
+Copyright (c) 2003-2020, John Hurst
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/KM_namespace.h.template
+++ b/src/KM_namespace.h.template
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2020, John Hurst
+Copyright (c) 2020, Dolby Laboratories
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/KM_namespace.h.template
+++ b/src/KM_namespace.h.template
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2013-2013, John Hurst
+Copyright (c) 2003-2014, John Hurst
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,20 +24,24 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-/*! \file    CRC16.h
-    \version $Id$
-    \brief   Declaration of a CRC function
-*/
 
-#ifndef _CRC_16_H_
-#define _CRC_16_H_
+#ifndef _KM_NAMESPACE_H_
+#define _KM_NAMESPACE_H_
 
-#include "AS_DCP_namespace.h"
+#cmakedefine KUMU_NAMESPACE @KUMU_NAMESPACE@
 
-ASDCP_NAMESPACE_BEGIN
+#ifndef KUMU_NAMESPACE
+	#define KUMU_NAMESPACE Kumu
+	#define KUMU_NAMESPACE_BEGIN namespace Kumu {
+	#define KUMU_NAMESPACE_END  }
+	#define KUMU_NAMESPACE_USE using namespace Kumu;
+#else
+	#define KUMU_NAMESPACE_BEGIN namespace @KUMU_NAMESPACE@ {
+	#define KUMU_NAMESPACE_END  }
+	#define KUMU_NAMESPACE_USE using namespace @KUMU_NAMESPACE@;
 
-unsigned short CRC16(const void *pData, int ilength);
-
-ASDCP_NAMESPACE_END
-
+	namespace @KUMU_NAMESPACE@ { }
+	namespace Kumu = @KUMU_NAMESPACE@;
 #endif
+
+#endif //_KM_NAMESPACE_H_

--- a/src/KM_platform.h
+++ b/src/KM_platform.h
@@ -32,6 +32,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _KM_PLATFORM_H_
 # define _KM_PLATFORM_H_
 
+#include "KM_namespace.h"
+
 #if defined(__APPLE__) && defined(__MACH__)
 #  define KM_MACOSX
 #  ifdef __BIG_ENDIAN__
@@ -77,8 +79,8 @@ typedef int            i32_t;
 typedef unsigned int   ui32_t;
 
 
-namespace Kumu
-{
+KUMU_NAMESPACE_BEGIN
+
   inline ui16_t Swap2(ui16_t i)
     {
       return ( (i << 8) | (( i & 0xff00) >> 8) );
@@ -183,7 +185,7 @@ namespace Kumu
       inline bool empty()      const { return m_p == 0; }
     };
 
-} // namespace Kumu
+KUMU_NAMESPACE_END
 
 // Produces copy constructor boilerplate. Allows convenient private
 // declatarion of copy constructors to prevent the compiler from

--- a/src/KM_prng.h
+++ b/src/KM_prng.h
@@ -34,8 +34,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <KM_util.h>
 
-namespace Kumu
-{
+KUMU_NAMESPACE_BEGIN
+
   class FortunaRNG
     {
       KM_NO_COPY_CONSTRUCT(FortunaRNG);
@@ -51,8 +51,7 @@ namespace Kumu
   // key_len must be <= 64 (larger values will be truncated)
   void Gen_FIPS_186_Value(const byte_t* key_in, ui32_t key_len, byte_t* buf, ui32_t buf_len);
 
-} // namespace Kumu
-
+KUMU_NAMESPACE_END
 
 
 #endif // _KM_PRNG_H_

--- a/src/KM_tai.h
+++ b/src/KM_tai.h
@@ -54,8 +54,8 @@ The libtai source code is in the public domain.
 #include <KM_platform.h>
 
 //
-namespace Kumu
-{
+KUMU_NAMESPACE_BEGIN
+
   namespace TAI
   {
     class caltime;
@@ -97,7 +97,7 @@ namespace Kumu
 
   } // namespace TAI
 
-} // namespace Kumu
+KUMU_NAMESPACE_END
 
 
 #endif // _KUMU_TAI_H_

--- a/src/KM_util.cpp
+++ b/src/KM_util.cpp
@@ -593,7 +593,7 @@ Kumu::GenRandomValue(UUID& ID)
 void
 Kumu::GenRandomUUID(byte_t* buf)
 {
-  FortunaRNG RNG;
+  Kumu::FortunaRNG RNG;
   RNG.FillRandom(buf, UUID_Length);
   buf[6] &= 0x0f; // clear bits 4-7
   buf[6] |= 0x40; // set UUID version
@@ -606,7 +606,7 @@ void
 Kumu::GenRandomValue(SymmetricKey& Key)
 {
   byte_t tmp_buf[SymmetricKey_Length];
-  FortunaRNG RNG;
+  Kumu::FortunaRNG RNG;
   RNG.FillRandom(tmp_buf, SymmetricKey_Length);
   Key.Set(tmp_buf);
 }

--- a/src/KM_util.h
+++ b/src/KM_util.h
@@ -38,8 +38,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <list>
 
-namespace Kumu
-{
+KUMU_NAMESPACE_BEGIN
+
   // The version number declaration and explanation are in ../configure.ac
   const char* Version();
 
@@ -607,7 +607,7 @@ namespace Kumu
       return result;
     }
 
-} // namespace Kumu
+KUMU_NAMESPACE_END
 
 
 #endif // _KM_UTIL_H_

--- a/src/KM_xml.h
+++ b/src/KM_xml.h
@@ -38,8 +38,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <set>
 #include <string>
 
-namespace Kumu
-{
+KUMU_NAMESPACE_BEGIN
+
   class XMLElement;
 
   //
@@ -215,7 +215,7 @@ namespace Kumu
     }
   };
 
-} // namespace Kumu
+KUMU_NAMESPACE_END
 
 #endif // _KM_XML_H_
 

--- a/src/MDD.h
+++ b/src/MDD.h
@@ -33,7 +33,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _MDD_H_
 
 //
-namespace ASDCP {
+ASDCP_NAMESPACE_BEGIN
     enum MDD_t {
         MDD_MICAlgorithm_NONE,  // 0
         MDD_MXFInterop_OPAtom,  // 1
@@ -584,7 +584,7 @@ namespace ASDCP {
     const MDD_t MDD_Preface_OperationalPattern = MDD_Core_OperationalPattern;
     const MDD_t MDD_TimedTextResourceSubDescriptor_EssenceStreamID = MDD_Core_BodySID;
 
-} // namespaceASDCP
+ASDCP_NAMESPACE_END
 
 
 #endif // _MDD_H_

--- a/src/MPEG.h
+++ b/src/MPEG.h
@@ -38,8 +38,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assert.h>
 
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
   namespace MPEG2
     {
       //
@@ -235,7 +235,7 @@ namespace ASDCP
 
     } // namespace MPEG2
 
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 #endif // _MPEG_H_
 

--- a/src/MXF.h
+++ b/src/MXF.h
@@ -35,8 +35,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "MXFTypes.h"
 #include <algorithm>
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
   namespace MXF
     {
       class InterchangeObject;
@@ -556,8 +556,7 @@ namespace ASDCP
 	};
 
     } // namespace MXF
-} // namespace ASDCP
-
+ASDCP_NAMESPACE_END
 
 #endif // _MXF_H_
 

--- a/src/MXFTypes.h
+++ b/src/MXFTypes.h
@@ -50,8 +50,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define OBJ_TYPE_ARGS(t) m_Dict->Type(MDD_##t).ul
 
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
   namespace MXF
     {
       typedef std::pair<ui32_t, ui32_t> ItemInfo;
@@ -705,8 +705,7 @@ namespace ASDCP
       };
 
     } // namespace MXF
-} // namespace ASDCP
-
+ASDCP_NAMESPACE_END
 
 #endif //_MXFTYPES_H_
 

--- a/src/Metadata.h
+++ b/src/Metadata.h
@@ -34,8 +34,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "MXF.h"
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
   namespace MXF
     {
       void Metadata_InitTypes(const Dictionary*& Dict);
@@ -1342,8 +1342,7 @@ namespace ASDCP
 	};
 
     } // namespace MXF
-} // namespace ASDCP
-
+ASDCP_NAMESPACE_END
 
 #endif // _Metadata_H_
 

--- a/src/PCMDataProviders.h
+++ b/src/PCMDataProviders.h
@@ -35,8 +35,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <AS_DCP.h>
 #include <AtmosSyncChannel_Generator.h>
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
 
   // PCM Data Provider Interface
   class PCMDataProviderInterface
@@ -110,7 +110,7 @@ namespace ASDCP
       virtual Result_t Reset();
   };
 
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 #endif // _PCMDATAPROVIDERS_H_
 

--- a/src/PCMParserList.h
+++ b/src/PCMParserList.h
@@ -36,8 +36,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <AS_DCP.h>
 #include <vector>
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
   //
   class ParserInstance
     {
@@ -80,8 +80,7 @@ namespace ASDCP
       Result_t ReadFrame(PCM::FrameBuffer& OutFB);
       Result_t Seek(ui32_t frame_number);
     };
-}
-
+ASDCP_NAMESPACE_END
 
 #endif // _PCMPARSERLIST_H_
 

--- a/src/S12MTimecode.h
+++ b/src/S12MTimecode.h
@@ -41,7 +41,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "KM_util.h"
 #include "KM_memio.h"
 
-namespace ASDCP {
+ASDCP_NAMESPACE_BEGIN
 
  class S12MTimecode : public Kumu::IArchive
 {
@@ -149,7 +149,7 @@ public:
 };
 
 
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 #endif // _S12MTIMECODE_H_
 

--- a/src/ST2095_PinkNoise.h
+++ b/src/ST2095_PinkNoise.h
@@ -43,8 +43,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
   // A source of pseudo-random numbers suitable for use in generating
   // noise signals.  NOT TO BE USED FOR CRYPTOGRAPHIC FUNCTIONS as its
   // output is 100% deterministic.
@@ -101,7 +101,7 @@ namespace ASDCP
   void ScalePackSample(float sample, byte_t* p, ui32_t word_size);
 
 
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 
 

--- a/src/SyncEncoder.cpp
+++ b/src/SyncEncoder.cpp
@@ -34,9 +34,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <memory.h>
 
-void ConstructFrame(LPSYNCENCODER	pSyncEncoder,
+static
+void ConstructFrame(ASDCP::LPSYNCENCODER	pSyncEncoder,
 					INT				iFrameIndex);
-
+static
 FLOAT SEWriteBits(	INT			iSampleRate,		/* In:	Sample rate of signal */
 					FLOAT		*pfAudioBuffer,		/* Out: Audio buffer containing signal */
 					INT			iBits,				/* In:	Number of bits to write */
@@ -45,7 +46,7 @@ FLOAT SEWriteBits(	INT			iSampleRate,		/* In:	Sample rate of signal */
 
 
 
-INT SyncEncoderInit(LPSYNCENCODER		pSyncEncoder,	/* Out: SYNCENCODER structure to be initialized */
+INT ASDCP::SyncEncoderInit(LPSYNCENCODER		pSyncEncoder,	/* Out: SYNCENCODER structure to be initialized */
 					INT					iSampleRate,	/* In:	Signal sample rate */
 					INT					iFrameRate,		/* In:	frame rate */
 					LPUUIDINFORMATION	pUUID)			/* In:	UUID */
@@ -142,7 +143,7 @@ INT SyncEncoderInit(LPSYNCENCODER		pSyncEncoder,	/* Out: SYNCENCODER structure t
 	return pSyncEncoder->iError;
 }
 
-INT GetSyncEncoderAudioBufferLength(LPSYNCENCODER pSyncEncoder)	/* In: Sync encoder structure */
+INT ASDCP::GetSyncEncoderAudioBufferLength(LPSYNCENCODER pSyncEncoder)	/* In: Sync encoder structure */
 {
 	if(pSyncEncoder->iError != SYNC_ENCODER_ERROR_NONE){
 		return pSyncEncoder->iError;
@@ -153,7 +154,7 @@ INT GetSyncEncoderAudioBufferLength(LPSYNCENCODER pSyncEncoder)	/* In: Sync enco
 
 
 
-INT EncodeSync(	LPSYNCENCODER	pSyncEncoder,	/* In:	Sync encoder structure */
+INT ASDCP::EncodeSync(	LPSYNCENCODER	pSyncEncoder,	/* In:	Sync encoder structure */
 				INT				iBufferLength,	/* In:	Length of audio buffer */
 				FLOAT			*pfAudioBuffer,	/* Out: Audio buffer with signal */
 				INT				iFrameIndex)	/* In:	Frame Index */
@@ -188,7 +189,7 @@ INT EncodeSync(	LPSYNCENCODER	pSyncEncoder,	/* In:	Sync encoder structure */
 	return pSyncEncoder->iError;
 }
 
-void ConstructFrame(LPSYNCENCODER	pSyncEncoder,
+void ConstructFrame(ASDCP::LPSYNCENCODER	pSyncEncoder,
 					INT				iFrameIndex)
 {
 	USHORT	ushCRC;
@@ -231,7 +232,7 @@ void ConstructFrame(LPSYNCENCODER	pSyncEncoder,
 	pSyncEncoder->abyPacket[9] = byByte;
 
 	/* calculate CRC */
-	ushCRC = CRC16(&pSyncEncoder->abyPacket[2],MESSAGE_TOTAL_BYTES - 4);
+	ushCRC = ASDCP::CRC16(&pSyncEncoder->abyPacket[2],MESSAGE_TOTAL_BYTES - 4);
 
 	/* Insert CRC */
 	byByte = (unsigned char)((ushCRC >> 8) & 0XFF);

--- a/src/SyncEncoder.h
+++ b/src/SyncEncoder.h
@@ -32,12 +32,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _SYNC_ENCODER_H_
 #define _SYNC_ENCODER_H_
 
+#include "AS_DCP_namespace.h"
 #include "SyncCommon.h"
 #include "UUIDInformation.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+ASDCP_NAMESPACE_BEGIN
 
 typedef struct SyncEncoder{
 	INT				iSampleRate;			/* Signal sample rate */
@@ -78,9 +77,7 @@ INT EncodeSync(	LPSYNCENCODER	pSyncEncoder,	/* In:	Sync encoder structure */
 				FLOAT			*pfAudioBuffer,	/* Out: Audio buffer with signal */
 				INT				iFrameIndex);	/* In:	Frame Index */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+ASDCP_NAMESPACE_END
 
 #endif
 

--- a/src/UUIDInformation.cpp
+++ b/src/UUIDInformation.cpp
@@ -33,7 +33,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 
 
-void UUIDSynthesize(LPUUIDINFORMATION pUUID)
+void ASDCP::UUIDSynthesize(LPUUIDINFORMATION pUUID)
 {
 	INT n;
 
@@ -48,7 +48,7 @@ void UUIDSynthesize(LPUUIDINFORMATION pUUID)
 	pUUID->abyUUIDBytes[8] |= 0xA0;
 }
 
-void UUIDPrint(	FILE				*pFilePtr,
+void ASDCP::UUIDPrint(	FILE				*pFilePtr,
 				LPUUIDINFORMATION	pUUID)
 {
 	if(pFilePtr != NULL){
@@ -67,7 +67,7 @@ void UUIDPrint(	FILE				*pFilePtr,
 	}
 }
 
-void UUIDPrintFormated(	FILE				*pFilePtr,
+void ASDCP::UUIDPrintFormated(	FILE				*pFilePtr,
 						LPUUIDINFORMATION	pUUID)
 {
 	if(pFilePtr != NULL){

--- a/src/UUIDInformation.h
+++ b/src/UUIDInformation.h
@@ -32,12 +32,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _UUID_INFORMATION_H_
 #define _UUID_INFORMATION_H_
 
+#include "AS_DCP_namespace.h"
 #include "SyncCommon.h"
 #include <stdio.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+ASDCP_NAMESPACE_BEGIN
 
 typedef struct UUIInformation{
 	BYTE abyUUIDBytes[16];
@@ -51,8 +50,6 @@ void UUIDPrint(	FILE				*pFilePtr,
 void UUIDPrintFormated(	FILE				*pFilePtr,
 						LPUUIDINFORMATION	pUUID);
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+ASDCP_NAMESPACE_END
 
 #endif

--- a/src/Wav.h
+++ b/src/Wav.h
@@ -35,8 +35,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <KM_fileio.h>
 #include <AS_DCP.h>
 
-namespace ASDCP
-{
+ASDCP_NAMESPACE_BEGIN
+
   //
   class fourcc
     {
@@ -158,7 +158,7 @@ namespace ASDCP
 	};
 
     } // namespace RF64
-} // namespace ASDCP
+ASDCP_NAMESPACE_END
 
 #endif // _WAV_H_
 

--- a/src/as-02-unwrap.cpp
+++ b/src/as-02-unwrap.cpp
@@ -41,9 +41,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "AS_02_ACES.h"
 #include <WavFileWriter.h>
 
-namespace ASDCP {
+ASDCP_NAMESPACE_BEGIN
   Result_t MD_to_PCM_ADesc(ASDCP::MXF::WaveAudioDescriptor* ADescObj, ASDCP::PCM::AudioDescriptor& ADesc);
-}
+ASDCP_NAMESPACE_END
 
 using namespace ASDCP;
 

--- a/src/as-02-wrap.cpp
+++ b/src/as-02-wrap.cpp
@@ -967,14 +967,14 @@ public:
 //------------------------------------------------------------------------------------------
 // JPEG 2000 essence
 
-namespace ASDCP {
+ASDCP_NAMESPACE_BEGIN
   Result_t JP2K_PDesc_to_MD(const ASDCP::JP2K::PictureDescriptor& PDesc,
 			    const ASDCP::Dictionary& dict,
 			    ASDCP::MXF::GenericPictureEssenceDescriptor& GenericPictureEssenceDescriptor,
 			    ASDCP::MXF::JPEG2000PictureSubDescriptor& EssenceSubDescriptor);
 
   Result_t PCM_ADesc_to_MD(ASDCP::PCM::AudioDescriptor& ADesc, ASDCP::MXF::WaveAudioDescriptor* ADescObj);
-}
+ASDCP_NAMESPACE_END
 
 // Write one or more plaintext JPEG 2000 codestreams to a plaintext AS-02 file
 // Write one or more plaintext JPEG 2000 codestreams to a ciphertext AS-02 file

--- a/src/phdr-wrap.cpp
+++ b/src/phdr-wrap.cpp
@@ -452,12 +452,12 @@ public:
 //------------------------------------------------------------------------------------------
 // JPEG 2000 essence
 
-namespace ASDCP {
+ASDCP_NAMESPACE_BEGIN
   Result_t JP2K_PDesc_to_MD(const ASDCP::JP2K::PictureDescriptor& PDesc,
 			    const ASDCP::Dictionary& dict,
 			    ASDCP::MXF::GenericPictureEssenceDescriptor& GenericPictureEssenceDescriptor,
 			    ASDCP::MXF::JPEG2000PictureSubDescriptor& EssenceSubDescriptor);
-}
+ASDCP_NAMESPACE_END
 
 // Write one or more plaintext JPEG 2000 codestreams to a plaintext AS-02 file
 // Write one or more plaintext JPEG 2000 codestreams to a ciphertext AS-02 file


### PR DESCRIPTION
Use CMake definitions to override the default library namespaces.
This can be useful when including asdcplib's objects in another static library in order to avoid symbol clashes in applications that link to both asdcplib and the library including asdcplib.