### PR TITLE
Dolby/Add GitHub continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build_ubuntu_autoconf:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: autoreconf
+      run: autoreconf -if
+    - name: configure
+      run: ./configure --enable-as-02
+    - name: make
+      run: make
+
+  build_ubuntu_cmake:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: dependencies
+      run: sudo apt-get update && sudo apt-get install -y
+        libxerces-c-dev
+    - name: Create build dir
+      run: mkdir build
+    - name: cmake
+      working-directory: build
+      run: cmake ..
+    - name: make
+      working-directory: build
+      run: make

--- a/configure.ac
+++ b/configure.ac
@@ -136,5 +136,5 @@ AC_CHECK_LIB([pthread], [pthread_create])
 AC_CONFIG_FILES([Makefile
                  src/Makefile
 		 win32/Makefile
-		 win32/Makefile.mak:win32/Makefile.wmk])
+		 win32/Makefile.mak:win32/Makefile32.wmk])
 AC_OUTPUT


### PR DESCRIPTION
Add CI to GitHub.
Run both autoconf and cmake builds.
For now, run Ubuntu only builds.
@jhursty let me know which type of builds/platforms it would be good to add.

This PR also includes the change from #49 to fix autoconf build.