### PR TITLE
Fix overflow read

### DIFF
--- a/src/AS_DCP_JP2K.cpp
+++ b/src/AS_DCP_JP2K.cpp
@@ -319,7 +319,7 @@ ASDCP::JP2K_PDesc_to_MD(const JP2K::PictureDescriptor& PDesc,
   EssenceSubDescriptor.PictureComponentSizing.set_has_value();
 
   ui32_t precinct_set_size = 0;
-  for ( ui32_t i = 0; PDesc.CodingStyleDefault.SPcod.PrecinctSize[i] != 0 && i < MaxPrecincts; ++i )
+  for ( ui32_t i = 0; i < MaxPrecincts && PDesc.CodingStyleDefault.SPcod.PrecinctSize[i] != 0; ++i )
     precinct_set_size++;
 
   ui32_t csd_size = sizeof(CodingStyleDefault_t) - MaxPrecincts + precinct_set_size;


### PR DESCRIPTION
Change order of instructions to check index prior to accessing the buffer. Otherwise we might read past allocated buffer.

I've found this issue after activating address sanitizer in one of our project (like done in #35).
I suggest you merge that part of #35 at least: from my experience sanitizers are really useful. I can work on splitting #35 if that could help. 