### PR TITLE
Fix misaligned reads

### DIFF
--- a/src/KM_platform.h
+++ b/src/KM_platform.h
@@ -64,6 +64,7 @@ typedef long long          i64_t;
 # endif // KM_WIN32
 
 # include <stdio.h>
+# include <string.h>
 # include <assert.h>
 # include <stdlib.h>
 # include <limits.h>
@@ -135,11 +136,17 @@ namespace Kumu
 
   // read an integer from byte-structured storage
   template<class T>
-  inline T    cp2i(const byte_t* p) { return *(T*)p; }
+  inline T    cp2i(const byte_t* p) {
+    T value;
+    memcpy(&value, p, sizeof(T));
+    return value;
+  }
 
   // write an integer to byte-structured storage
   template<class T>
-  inline void i2p(T i, byte_t* p) { *(T*)p = i; }
+  inline void i2p(T i, byte_t* p) {
+      memcpy(p, &i, sizeof(T));
+  }
 
 
 # ifdef KM_BIG_ENDIAN

--- a/src/MXFTypes.cpp
+++ b/src/MXFTypes.cpp
@@ -286,7 +286,9 @@ ASDCP::MXF::UTF16String::Unarchive(Kumu::MemIOReader* Reader)
 
   for ( ui32_t i = 0; i < length; i++ )
     {
-      int count = wcrtomb(mb_buf, KM_i16_BE(p[i]), &ps);
+      ui16_t pi;
+      memcpy(&pi, &p[i], sizeof(ui16_t));
+      int count = wcrtomb(mb_buf, KM_i16_BE(pi), &ps);
 
       if ( count == -1 )
 	{


### PR DESCRIPTION
Found those issues after activating clang "undefined behavior" sanitizer (using `-fsanitize=undefined`, more information available [here](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html))
I must confess I'm not familiar with alignments problems so I wasn't sure how critical this was.
After digging a bit, I understood some processors don't like unaligned addresses, though x86 processors can deal with this in most cases. Still, x86 CPUs can have trouble with this under some circumstances.
I've found this article that describes quite well the kind of problems you can face: https://blog.quarkslab.com/unaligned-accesses-in-cc-what-why-and-solutions-to-do-it-properly.html
This one gives more insight about x86 in particular: http://pzemtsov.github.io/2016/11/06/bug-story-alignment-on-x86.html
IMHO even if the current code should work most of the time, it sounds safer to make it more portable to be sure it will always behave as expected.