### PR TITLE
Add new cmake option to build static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,11 @@ STRING(REGEX REPLACE "([0-9]+)[.].*" "\\1" VERSION_MAJOR ${VERSION_STRING})
 STRING(REGEX REPLACE ".*[.]([0-9]+)[.].*" "\\1" VERSION_MINOR ${VERSION_STRING})
 STRING(REGEX REPLACE ".*[.]+([0-9]+)" "\\1" VERSION_PATCH ${VERSION_STRING})
 message(STATUS "Version Number is ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "Default Targets")
+option(BUILD_STATIC_LIBS "Enable building static asdcp libraries" OFF) 
+
 # use, i.e. don't skip the full RPATH for the build tree
 set(CMAKE_SKIP_BUILD_RPATH  OFF)
 # when building, don't use the install RPATH already

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,15 +62,21 @@ endif(UseRandomUUID)
 
 set(CMAKE_DEBUG_POSTFIX _d) # Append "_d" if debug lib.
 
-add_library(libkumu ${kumu_src})
+if (BUILD_STATIC_LIBS)
+    set(BUILD_TYPE "STATIC")
+else()
+    set(BUILD_TYPE "SHARED")
+endif()
+
+add_library(libkumu ${BUILD_TYPE} ${kumu_src})
 target_link_libraries(libkumu general "${OpenSSLLib_PATH}" debug "${XercescppLib_Debug_PATH}" optimized "${XercescppLib_PATH}")
 set_target_properties(libkumu PROPERTIES PREFIX "" VERSION ${VERSION_STRING} SOVERSION ${VERSION_MAJOR})
 
-add_library(libasdcp ${asdcp_src})
+add_library(libasdcp ${BUILD_TYPE} ${asdcp_src})
 target_link_libraries(libasdcp general libkumu)
 set_target_properties(libasdcp PROPERTIES PREFIX "" VERSION ${VERSION_STRING} SOVERSION ${VERSION_MAJOR})
 
-add_library(libas02 ${as02_src})
+add_library(libas02 ${BUILD_TYPE} ${as02_src})
 target_link_libraries(libas02 general libasdcp)
 set_target_properties(libas02 PROPERTIES PREFIX "" VERSION ${VERSION_STRING} SOVERSION ${VERSION_MAJOR})
 


### PR DESCRIPTION
# What does this PR do?
Add new CMake option to build static libraries
## Explanation
Sometime it is useful to build static libraries instead of shared ones and link them directly to a binary.

## Solution
Introduce new CMake option `BUILD_STATIC_LIBS`

## How to test?

### Build shared libs

1. `mkdir build`
1. `cd build`
1. `cmake ..`

One should be able to see ASDCP shared libs (`*.so` files on Linux)


### Build static libs

1. `mkdir build`
1. `cd build`
1. `cmake -DBUILD_STATIC_LIBS=ON ..`

One should be able to see ASDCP static libs (`*.a` files on Linux)
