### PR TITLE
Update the CI to also build without XML or without SSL support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,33 @@ jobs:
     - name: make
       working-directory: build
       run: make
+
+  build_ubuntu_cmake_without_ssl:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Create build dir
+      run: mkdir build
+    - name: cmake
+      working-directory: build
+      run: cmake .. -DWITHOUT_SSL=ON
+    - name: make
+      working-directory: build
+      run: make
+
+  build_ubuntu_cmake_without_xml:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Create build dir
+      run: mkdir build
+    - name: cmake
+      working-directory: build
+      run: cmake .. -DWITHOUT_XML=ON
+    - name: make
+      working-directory: build
+      run: make


### PR DESCRIPTION
Update the CI to also build without XML or without SSL support, to ensure this doesn't get broken with a future change, like this was the case in the past (see issue cinecert#80)
This was tested in our fork (https://github.com/DolbyLaboratories/asdcplib/pull/3)