### PR TITLE
CI: add JPEG XS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,21 @@ jobs:
     - name: make
       working-directory: build
       run: make
+
+  build_ubuntu_cmake_with_jxs:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: dependencies
+      run: sudo apt-get update && sudo apt-get install -y
+        libxerces-c-dev
+    - name: Create build dir
+      run: mkdir build
+    - name: cmake
+      working-directory: build
+      run: cmake .. -DUSE_ASDCP_JXS=ON
+    - name: make
+      working-directory: build
+      run: make


### PR DESCRIPTION
This would need to be integrated after #99 is merged.
This would prevent compilation error like the one fixed in #99 to go unnoticed. 