### PR TITLE
correctly handle WAVE files that don't end with the "data" chunk

### DIFF
--- a/src/PCM_Parser.cpp
+++ b/src/PCM_Parser.cpp
@@ -170,9 +170,9 @@ ASDCP::PCM::WAVParser::h__WAVParser::ReadFrame(FrameBuffer& FB)
     }
 
   ui32_t read_count = 0;
-  Result_t result = m_FileReader.Read(FB.Data(), m_FrameBufferSize, &read_count);
+  Result_t result = m_FileReader.Read(FB.Data(), (m_DataLength - m_ReadCount >= m_FrameBufferSize) ? m_FrameBufferSize : m_DataLength - m_ReadCount, &read_count);
 
-  if ( result == RESULT_ENDOFFILE )
+  if ( result == RESULT_ENDOFFILE || (m_DataLength == m_ReadCount + read_count) )
     {
       m_EOF = true;
 


### PR DESCRIPTION
Sometimes an audio tool will create WAV files in which the `data` chunk is not located at the end of the file. When that occurs, `asdcplib` reads past the end of the chunk boundary. This patch corrects that behavior.
