### PR TITLE
Issues/0111 tt write to root

### DIFF
--- a/src/asdcp-test.cpp
+++ b/src/asdcp-test.cpp
@@ -1670,6 +1670,11 @@ read_timed_text_file(CommandOptions& Options, const Kumu::IFileReaderFactory& fi
 	result = Writer.Write(reinterpret_cast<const byte_t*>(XMLDoc.c_str()), XMLDoc.size(), &write_count);
     }
 
+  /* if empty out_path, store ancillary resources in current directory */
+  if (out_path == "")
+    {
+      out_path = "./";
+    }
   for ( ri = TDesc.ResourceList.begin() ; ri != TDesc.ResourceList.end() && ASDCP_SUCCESS(result); ri++ )
     {
       result = Reader.ReadAncillaryResource(ri->ResourceID, FrameBuffer, Context, HMAC);

--- a/src/asdcp-test.cpp
+++ b/src/asdcp-test.cpp
@@ -1673,7 +1673,7 @@ read_timed_text_file(CommandOptions& Options, const Kumu::IFileReaderFactory& fi
   /* if empty out_path, store ancillary resources in current directory */
   if (out_path == "")
     {
-      out_path = "./";
+      out_path = Kumu::PathJoin(".", out_path);
     }
   for ( ri = TDesc.ResourceList.begin() ; ri != TDesc.ResourceList.end() && ASDCP_SUCCESS(result); ri++ )
     {

--- a/src/asdcp-test.cpp
+++ b/src/asdcp-test.cpp
@@ -1673,7 +1673,7 @@ read_timed_text_file(CommandOptions& Options, const Kumu::IFileReaderFactory& fi
   /* if empty out_path, store ancillary resources in current directory */
   if (out_path == "")
     {
-      out_path = Kumu::PathJoin(".", out_path);
+      out_path = ".";
     }
   for ( ri = TDesc.ResourceList.begin() ; ri != TDesc.ResourceList.end() && ASDCP_SUCCESS(result); ri++ )
     {

--- a/src/asdcp-unwrap.cpp
+++ b/src/asdcp-unwrap.cpp
@@ -845,7 +845,7 @@ read_timed_text_file(CommandOptions& Options, const Kumu::IFileReaderFactory& fi
   /* if empty out_path, store ancillary resources in current directory */
   if (out_path == "")
     {
-      out_path = "./";
+      out_path = Kumu::PathJoin(".", out_path);
     }
   for ( ri = TDesc.ResourceList.begin() ; ri != TDesc.ResourceList.end() && ASDCP_SUCCESS(result); ri++ )
     {

--- a/src/asdcp-unwrap.cpp
+++ b/src/asdcp-unwrap.cpp
@@ -845,7 +845,7 @@ read_timed_text_file(CommandOptions& Options, const Kumu::IFileReaderFactory& fi
   /* if empty out_path, store ancillary resources in current directory */
   if (out_path == "")
     {
-      out_path = Kumu::PathJoin(".", out_path);
+      out_path = ".";
     }
   for ( ri = TDesc.ResourceList.begin() ; ri != TDesc.ResourceList.end() && ASDCP_SUCCESS(result); ri++ )
     {

--- a/src/asdcp-unwrap.cpp
+++ b/src/asdcp-unwrap.cpp
@@ -842,6 +842,11 @@ read_timed_text_file(CommandOptions& Options, const Kumu::IFileReaderFactory& fi
 	result = Writer.Write(reinterpret_cast<const byte_t*>(XMLDoc.c_str()), XMLDoc.size(), &write_count);
     }
 
+  /* if empty out_path, store ancillary resources in current directory */
+  if (out_path == "")
+    {
+      out_path = "./";
+    }
   for ( ri = TDesc.ResourceList.begin() ; ri != TDesc.ResourceList.end() && ASDCP_SUCCESS(result); ri++ )
     {
       result = Reader.ReadAncillaryResource(ri->ResourceID, FrameBuffer, Context, HMAC);


### PR DESCRIPTION
Issue https://github.com/cinecert/asdcplib/issues/111

If path to &lt;file-prefix> or &lt;root-name> is "", then write ancillary resources in the current directory by using "." path syntax.
