### PR TITLE
Fix misaligned reads when readin/writing audio

### DIFF
--- a/src/AS_DCP_MXF.cpp
+++ b/src/AS_DCP_MXF.cpp
@@ -630,8 +630,7 @@ ASDCP::IntegrityPack::CalcValues(const ASDCP::FrameBuffer& FB, const byte_t* Ass
   p += MXF_BER_LENGTH;
 
   // sequence number
-  Kumu::i2p<ui64_t>(KM_i64_BE(sequence), p);
-  p += sizeof(ui64_t);
+  p += Kumu::i2p<ui64_t>(KM_i64_BE(sequence), p);
 
   // HMAC length
   memcpy(p, ber_4, MXF_BER_LENGTH);

--- a/src/KM_memio.h
+++ b/src/KM_memio.h
@@ -99,8 +99,7 @@ namespace Kumu
 	if ( ( m_size + sizeof(ui16_t) ) > m_capacity )
 	  return false;
 	
-	i2p<ui16_t>(KM_i16_BE(i), m_p + m_size);
-	m_size += sizeof(ui16_t);
+	m_size += i2p<ui16_t>(KM_i16_BE(i), m_p + m_size);
 	return true;
       }
 
@@ -108,8 +107,7 @@ namespace Kumu
 	if ( ( m_size + sizeof(ui32_t) ) > m_capacity )
 	  return false;
 	
-	i2p<ui32_t>(KM_i32_BE(i), m_p + m_size);
-	m_size += sizeof(ui32_t);
+	m_size += i2p<ui32_t>(KM_i32_BE(i), m_p + m_size);
 	return true;
       }
 
@@ -117,8 +115,7 @@ namespace Kumu
 	if ( ( m_size + sizeof(ui64_t) ) > m_capacity )
 	  return false;
 	
-	i2p<ui64_t>(KM_i64_BE(i), m_p + m_size);
-	m_size += sizeof(ui64_t);
+	m_size += i2p<ui64_t>(KM_i64_BE(i), m_p + m_size);
 	return true;
       }
 

--- a/src/KM_platform.h
+++ b/src/KM_platform.h
@@ -147,9 +147,11 @@ namespace Kumu
   }
 
   // write an integer to byte-structured storage
+  // returns the number of bytes written
   template<class T>
-  inline void i2p(T i, byte_t* p) {
+  inline size_t i2p(T i, byte_t* p) {
       memcpy(p, &i, sizeof(T));
+      return sizeof(T);
   }
 
 

--- a/src/Wav.cpp
+++ b/src/Wav.cpp
@@ -32,6 +32,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Wav.h"
 #include <assert.h>
 #include <KM_log.h>
+#include <KM_platform.h>
 using Kumu::DefaultLogSink;
 
 
@@ -88,20 +89,20 @@ ASDCP::Wav::SimpleWaveHeader::WriteToFile(Kumu::FileWriter& OutFile) const
 
   ui32_t RIFF_len = data_len + SimpleWavHeaderLength - 8;
 
-  memcpy(p, &FCC_RIFF, sizeof(fourcc)); p += 4;
-  *((ui32_t*)p) = KM_i32_LE(RIFF_len); p += 4;
-  memcpy(p, &FCC_WAVE, sizeof(fourcc)); p += 4;
-  memcpy(p, &FCC_fmt_, sizeof(fourcc)); p += 4;
-  *((ui32_t*)p) = KM_i32_LE(fmt_len); p += 4;
-  *((ui16_t*)p) = KM_i16_LE(format); p += 2;
-  *((ui16_t*)p) = KM_i16_LE(nchannels); p += 2;
-  *((ui32_t*)p) = KM_i32_LE(samplespersec); p += 4;
-  *((ui32_t*)p) = KM_i32_LE(avgbps); p += 4;
-  *((ui16_t*)p) = KM_i16_LE(blockalign); p += 2;
-  *((ui16_t*)p) = KM_i16_LE(bitspersample); p += 2;
-  *((ui16_t*)p) = KM_i16_LE(cbsize); p += 2;
-  memcpy(p, &FCC_data, sizeof(fourcc)); p += 4;
-  *((ui32_t*)p) = KM_i32_LE(data_len); p += 4;
+  p += Kumu::i2p<fourcc>(FCC_RIFF, p);
+  p += Kumu::i2p<ui32_t>(KM_i32_LE(RIFF_len), p);
+  p += Kumu::i2p<fourcc>(FCC_WAVE, p);
+  p += Kumu::i2p<fourcc>(FCC_fmt_, p);
+  p += Kumu::i2p<ui32_t>(KM_i32_LE(fmt_len), p);
+  p += Kumu::i2p<ui16_t>(KM_i16_LE(format), p);
+  p += Kumu::i2p<ui16_t>(KM_i16_LE(nchannels), p);
+  p += Kumu::i2p<ui32_t>(KM_i32_LE(samplespersec), p);
+  p += Kumu::i2p<ui32_t>(KM_i32_LE(avgbps), p);
+  p += Kumu::i2p<ui16_t>(KM_i16_LE(blockalign), p);
+  p += Kumu::i2p<ui16_t>(KM_i16_LE(bitspersample), p);
+  p += Kumu::i2p<ui16_t>(KM_i16_LE(cbsize), p);
+  p += Kumu::i2p<fourcc>(FCC_data, p);
+  p += Kumu::i2p<ui32_t>(KM_i32_LE(data_len), p);
 
   return OutFile.Write(tmp_header, SimpleWavHeaderLength, &write_count);
 }
@@ -142,7 +143,7 @@ ASDCP::Wav::SimpleWaveHeader::ReadFromBuffer(const byte_t* buf, ui32_t buf_len, 
       return RESULT_RAW_FORMAT;
     }
 
-  ui32_t RIFF_len = KM_i32_LE(*(ui32_t*)p); p += 4;
+  ui32_t RIFF_len = KM_i32_LE(Kumu::cp2i<ui32_t>(p)); p += sizeof(ui32_t);
 
   fourcc test_WAVE(p); p += 4;
   if ( test_WAVE != FCC_WAVE )
@@ -156,7 +157,7 @@ ASDCP::Wav::SimpleWaveHeader::ReadFromBuffer(const byte_t* buf, ui32_t buf_len, 
   while ( p < end_p )
     {
       test_fcc = fourcc(p); p += 4;
-      ui32_t chunk_size = KM_i32_LE(*(ui32_t*)p); p += 4;
+      ui32_t chunk_size = KM_i32_LE(Kumu::cp2i<ui32_t>(p)); p += sizeof(ui32_t);
 
       if ( test_fcc == FCC_data )
 	{
@@ -181,11 +182,11 @@ ASDCP::Wav::SimpleWaveHeader::ReadFromBuffer(const byte_t* buf, ui32_t buf_len, 
 	      return RESULT_RAW_FORMAT;
 	    }
 
-	  nchannels = KM_i16_LE(*(ui16_t*)p); p += 2;
-	  samplespersec = KM_i32_LE(*(ui32_t*)p); p += 4;
-	  avgbps = KM_i32_LE(*(ui32_t*)p); p += 4;
-	  blockalign = KM_i16_LE(*(ui16_t*)p); p += 2;
-	  bitspersample = KM_i16_LE(*(ui16_t*)p); p += 2;
+	  nchannels = KM_i16_LE(Kumu::cp2i<ui16_t>(p)); p += sizeof(ui16_t);
+	  samplespersec = KM_i32_LE(Kumu::cp2i<ui32_t>(p)); p += sizeof(ui32_t);
+	  avgbps = KM_i32_LE(Kumu::cp2i<ui32_t>(p)); p += sizeof(ui32_t);
+	  blockalign = KM_i16_LE(Kumu::cp2i<ui16_t>(p)); p += sizeof(ui16_t);
+	  bitspersample = KM_i16_LE(Kumu::cp2i<ui16_t>(p)); p += sizeof(ui16_t);
 	  p += chunk_size - 16; // 16 is the number of bytes read in this block
 	}
       else
@@ -235,7 +236,7 @@ Rat_to_extended(ASDCP::Rational rate, byte_t* buf)
        value <<= 1;
      }
 
-   *(ui32_t*)(buf+2) = KM_i32_BE(value);
+   Kumu::i2p<ui32_t>(KM_i32_BE(value), buf+2);
 }
 
 //
@@ -243,7 +244,7 @@ ASDCP::Rational
 extended_to_Rat(const byte_t* buf)
 {
   ui32_t last = 0;
-  ui32_t mantissa = KM_i32_BE(*(ui32_t*)(buf+2));
+  ui32_t mantissa = KM_i32_BE(Kumu::cp2i<ui32_t>(buf+2));
 
   byte_t exp = 30 - *(buf+1);
 
@@ -314,7 +315,7 @@ ASDCP::AIFF::SimpleAIFFHeader::ReadFromBuffer(const byte_t* buf, ui32_t buf_len,
       return RESULT_RAW_FORMAT;
     }
 
-  ui32_t RIFF_len = KM_i32_BE(*(ui32_t*)p); p += 4;
+  ui32_t RIFF_len = KM_i32_BE(Kumu::cp2i<ui32_t>(p)); p += sizeof(ui32_t);
 
   fourcc test_AIFF(p); p += 4;
   if ( test_AIFF != FCC_AIFF )
@@ -328,13 +329,13 @@ ASDCP::AIFF::SimpleAIFFHeader::ReadFromBuffer(const byte_t* buf, ui32_t buf_len,
   while ( p < end_p )
     {
       test_fcc = fourcc(p); p += 4;
-      ui32_t chunk_size = KM_i32_BE(*(ui32_t*)p); p += 4;
+      ui32_t chunk_size = KM_i32_BE(Kumu::cp2i<ui32_t>(p)); p += sizeof(ui32_t);
 
       if ( test_fcc == FCC_COMM )
 	{
-	  numChannels = KM_i16_BE(*(ui16_t*)p); p += 2;
-	  numSampleFrames = KM_i32_BE(*(ui32_t*)p); p += 4;
-	  sampleSize = KM_i16_BE(*(ui16_t*)p); p += 2;
+	  numChannels = KM_i16_BE(Kumu::cp2i<ui16_t>(p)); p += sizeof(ui16_t);
+	  numSampleFrames = KM_i32_BE(Kumu::cp2i<ui32_t>(p)); p += sizeof(ui32_t);
+	  sampleSize = KM_i16_BE(Kumu::cp2i<ui16_t>(p)); p += sizeof(ui16_t);
 	  memcpy(sampleRate, p, 10);
 	  p += 10;
 	}
@@ -346,7 +347,7 @@ ASDCP::AIFF::SimpleAIFFHeader::ReadFromBuffer(const byte_t* buf, ui32_t buf_len,
               return RESULT_RAW_FORMAT;
             }
 
-	  ui32_t offset = KM_i32_BE(*(ui32_t*)p); p += 4;
+	  ui32_t offset = KM_i32_BE(Kumu::cp2i<ui32_t>(p)); p += sizeof(ui32_t);
 	  p += 4; // blockSize;
 
 	  data_len = chunk_size - 8;
@@ -431,26 +432,26 @@ ASDCP::RF64::SimpleRF64Header::WriteToFile(Kumu::FileWriter& OutFile) const
     header_len = SIMPLE_RF64_HEADER_LEN;
     tmp_header = new byte_t[header_len];
     byte_t* p = tmp_header;
-    memcpy(p, &FCC_RF64, sizeof(fourcc)); p += 4;
-    *((ui32_t*)p) = KM_i32_LE(MAX_RIFF_LEN); p += 4;
-    memcpy(p, &Wav::FCC_WAVE, sizeof(fourcc)); p += 4;
-    memcpy(p, &FCC_ds64, sizeof(fourcc)); p += 4;
-    *((ui32_t*)p) = KM_i32_LE(ds64_len); p += 4;
-    *((ui64_t*)p) = KM_i64_LE(RIFF_len); p += 8;
-    *((ui64_t*)p) = KM_i64_LE(data64_len); p += 8;
-    *((ui64_t*)p) = KM_i64_LE(SAMPLE_COUNT); p += 8;
-    *((ui32_t*)p) = KM_i32_LE(TABLE_LEN); p += 4;
-    memcpy(p, &Wav::FCC_fmt_, sizeof(fourcc)); p += 4;
-    *((ui32_t*)p) = KM_i32_LE(fmt_len); p += 4;
-    *((ui16_t*)p) = KM_i16_LE(format); p += 2;
-    *((ui16_t*)p) = KM_i16_LE(nchannels); p += 2;
-    *((ui32_t*)p) = KM_i32_LE(samplespersec); p += 4;
-    *((ui32_t*)p) = KM_i32_LE(avgbps); p += 4;
-    *((ui16_t*)p) = KM_i16_LE(blockalign); p += 2;
-    *((ui16_t*)p) = KM_i16_LE(bitspersample); p += 2;
-    *((ui16_t*)p) = KM_i16_LE(cbsize); p += 2;
-    memcpy(p, &Wav::FCC_data, sizeof(fourcc)); p += 4;
-    *((ui32_t*)p) = KM_i32_LE(data32_len); p += 4;
+    p += Kumu::i2p<fourcc>(FCC_RF64, p);
+    p += Kumu::i2p<ui32_t>(KM_i32_LE(MAX_RIFF_LEN), p);
+    p += Kumu::i2p<fourcc>(Wav::FCC_WAVE, p);
+    p += Kumu::i2p<fourcc>(FCC_ds64, p);
+    p += Kumu::i2p<ui32_t>(KM_i32_LE(ds64_len), p);
+    p += Kumu::i2p<ui64_t>(KM_i64_LE(RIFF_len), p);
+    p += Kumu::i2p<ui64_t>(KM_i64_LE(data64_len), p);
+    p += Kumu::i2p<ui64_t>(KM_i64_LE(SAMPLE_COUNT), p);
+    p += Kumu::i2p<ui32_t>(KM_i32_LE(TABLE_LEN), p);
+    p += Kumu::i2p<fourcc>(Wav::FCC_fmt_, p);
+    p += Kumu::i2p<ui32_t>(KM_i32_LE(fmt_len), p);
+    p += Kumu::i2p<ui16_t>(KM_i16_LE(format), p);
+    p += Kumu::i2p<ui16_t>(KM_i16_LE(nchannels), p);
+    p += Kumu::i2p<ui32_t>(KM_i32_LE(samplespersec), p);
+    p += Kumu::i2p<ui32_t>(KM_i32_LE(avgbps), p);
+    p += Kumu::i2p<ui16_t>(KM_i16_LE(blockalign), p);
+    p += Kumu::i2p<ui16_t>(KM_i16_LE(bitspersample), p);
+    p += Kumu::i2p<ui16_t>(KM_i16_LE(cbsize), p);
+    p += Kumu::i2p<fourcc>(Wav::FCC_data, p);
+    p += Kumu::i2p<ui32_t>(KM_i32_LE(data32_len), p);
     write_count = (p - tmp_header);
   }
   else
@@ -459,20 +460,20 @@ ASDCP::RF64::SimpleRF64Header::WriteToFile(Kumu::FileWriter& OutFile) const
     header_len = SimpleWavHeaderLength;
     tmp_header = new byte_t[header_len];
     byte_t* p = tmp_header;
-    memcpy(p, &Wav::FCC_RIFF, sizeof(fourcc)); p += 4;
-    *((ui32_t*)p) = KM_i32_LE(RIFF_len); p += 4;
-    memcpy(p, &Wav::FCC_WAVE, sizeof(fourcc)); p += 4;
-    memcpy(p, &Wav::FCC_fmt_, sizeof(fourcc)); p += 4;
-    *((ui32_t*)p) = KM_i32_LE(fmt_len); p += 4;
-    *((ui16_t*)p) = KM_i16_LE(format); p += 2;
-    *((ui16_t*)p) = KM_i16_LE(nchannels); p += 2;
-    *((ui32_t*)p) = KM_i32_LE(samplespersec); p += 4;
-    *((ui32_t*)p) = KM_i32_LE(avgbps); p += 4;
-    *((ui16_t*)p) = KM_i16_LE(blockalign); p += 2;
-    *((ui16_t*)p) = KM_i16_LE(bitspersample); p += 2;
-    *((ui16_t*)p) = KM_i16_LE(cbsize); p += 2;
-    memcpy(p, &Wav::FCC_data, sizeof(fourcc)); p += 4;
-    *((ui32_t*)p) = KM_i32_LE(data_len); p += 4;
+    p += Kumu::i2p<fourcc>(Wav::FCC_RIFF, p);
+    p += Kumu::i2p<ui32_t>(KM_i32_LE(RIFF_len), p);
+    p += Kumu::i2p<fourcc>(Wav::FCC_WAVE, p);
+    p += Kumu::i2p<fourcc>(Wav::FCC_fmt_, p);
+    p += Kumu::i2p<ui32_t>(KM_i32_LE(fmt_len), p);
+    p += Kumu::i2p<ui16_t>(KM_i16_LE(format), p);
+    p += Kumu::i2p<ui16_t>(KM_i16_LE(nchannels), p);
+    p += Kumu::i2p<ui32_t>(KM_i32_LE(samplespersec), p);
+    p += Kumu::i2p<ui32_t>(KM_i32_LE(avgbps), p);
+    p += Kumu::i2p<ui16_t>(KM_i16_LE(blockalign), p);
+    p += Kumu::i2p<ui16_t>(KM_i16_LE(bitspersample), p);
+    p += Kumu::i2p<ui16_t>(KM_i16_LE(cbsize), p);
+    p += Kumu::i2p<fourcc>(Wav::FCC_data, p);
+    p += Kumu::i2p<ui32_t>(KM_i32_LE(data_len), p);
     write_count = (p - tmp_header);
   }
   if (header_len != write_count)
@@ -524,7 +525,7 @@ ASDCP::RF64::SimpleRF64Header::ReadFromBuffer(const byte_t* buf, ui32_t buf_len,
         return RESULT_RAW_FORMAT;
     }
 
-    ui32_t tmp_len = KM_i32_LE(*(ui32_t*)p); p += 4;
+    ui32_t tmp_len = KM_i32_LE(Kumu::cp2i<ui32_t>(p)); p += sizeof(ui32_t);
 
     fourcc test_WAVE(p); p += 4;
     if ( test_WAVE != Wav::FCC_WAVE )
@@ -539,9 +540,9 @@ ASDCP::RF64::SimpleRF64Header::ReadFromBuffer(const byte_t* buf, ui32_t buf_len,
         DefaultLogSink().Debug("File does not contain a ds64 chunk\n");
         return RESULT_RAW_FORMAT;
     }
-    ui32_t ds64_len = KM_i32_LE(*(ui32_t*)p); p += 4;
-    ui64_t RIFF_len = ((tmp_len == MAX_RIFF_LEN) ? KM_i64_LE(*(ui64_t*)p) : tmp_len); p += 8;
-    data_len = KM_i64_LE(*(ui64_t*)p); p += 8;
+    ui32_t ds64_len = KM_i32_LE(Kumu::cp2i<ui32_t>(p)); p += sizeof(ui32_t);
+    ui64_t RIFF_len = ((tmp_len == MAX_RIFF_LEN) ? KM_i64_LE(Kumu::cp2i<ui64_t>(p)) : tmp_len); p += 8;
+    data_len = KM_i64_LE(Kumu::cp2i<ui64_t>(p)); p += sizeof(ui64_t);
     p += (ds64_len - 16); // skip rest of ds64 chunk
 
     fourcc test_fcc;
@@ -549,7 +550,7 @@ ASDCP::RF64::SimpleRF64Header::ReadFromBuffer(const byte_t* buf, ui32_t buf_len,
     while ( p < end_p )
     {
         test_fcc = fourcc(p); p += 4;
-        ui32_t chunk_size = KM_i32_LE(*(ui32_t*)p); p += 4;
+        ui32_t chunk_size = KM_i32_LE(Kumu::cp2i<ui32_t>(p)); p += sizeof(ui32_t);
 
         if ( test_fcc == Wav::FCC_data )
         {
@@ -570,7 +571,7 @@ ASDCP::RF64::SimpleRF64Header::ReadFromBuffer(const byte_t* buf, ui32_t buf_len,
 
         if ( test_fcc == Wav::FCC_fmt_ )
         {
-            ui16_t format = KM_i16_LE(*(ui16_t*)p); p += 2;
+            ui16_t format = KM_i16_LE(Kumu::cp2i<ui16_t>(p)); p += sizeof(ui16_t);
 
             if ( format != Wav::ASDCP_WAVE_FORMAT_PCM && format != Wav::ASDCP_WAVE_FORMAT_EXTENSIBLE )
             {


### PR DESCRIPTION
This is similar to https://github.com/cinecert/asdcplib/pull/56 I fixed a while ago.

I noticed it when using Wav wrap/unwrap, with [sanitizers](https://github.com/google/sanitizers) activated.

Quoting the previous MR: "some processors don't like unaligned addresses, though x86 processors can deal with this in most cases. Still, x86 CPUs can have trouble with this under some circumstances.
I've found this article that describes quite well the kind of problems you can face: https://blog.quarkslab.com/unaligned-accesses-in-cc-what-why-and-solutions-to-do-it-properly.html
This one gives more insight about x86 in particular: http://pzemtsov.github.io/2016/11/06/bug-story-alignment-on-x86.html"

To build with sanitizers activated, I used:
`cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer" -DCMAKE_LDFLAGS="-fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer"`

Then to reproduce the issue:
`./asdcp-wrap file.wav file.mxf`
generates warnings like this:
```
asdcplib/src/Wav.cpp:159:27: runtime error: load of misaligned address 0x62d00000042a for type 'ui32_t' (aka 'unsigned int'), which requires 4 byte alignment
0x62d00000042a: note: pointer points here
 64 61  74 61 00 88 84 02 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00
 
             ^ 
```

and
```
./asdcp-unwrap file.mxf 
Will write out a regular wave file.
/Users/abien/Projects/Dolby/asdcplib/src/Wav.cpp:475:5: runtime error: store to misaligned address 0x604000033f7a for type 'ui32_t' (aka 'unsigned int'), which requires 4 byte alignment
0x604000033f7a: note: pointer points here
 64 61  74 61 be be be be 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/abien/Projects/Dolby/asdcplib/src/Wav.cpp:475:5 in 
```

So I used `memcpy` everywhere, through the existing `i2p` and `cp2i` functions.

I also modified `i2p` to return the number of bytes, to make the code more concise and limit the risk of errors by having to write another `sizeof` and possibly making a mistake and putting the wrong type here.