### PR TITLE
fix: improve autoconf handling of OpenSSL 1.x

### DIFF
--- a/m4/ax_lib_openssl.m4
+++ b/m4/ax_lib_openssl.m4
@@ -237,7 +237,7 @@ SSLeay();
                 if test -f "$openssl_include_dir/openssl/opensslv.h"; then
 
                     OPENSSL_VERSION=`grep OPENSSL_VERSION_TEXT $openssl_include_dir/openssl/opensslv.h \
-                                    | grep -v fips | grep -v PTEXT | sed -e 's/[ ][ ][ ]*/\t/g' | cut -f 2 | tr -d \"`
+                                    | grep -v fips | grep -v PTEXT | sed -e 's/^.*OPENSSL_VERSION_TEXT[ ]*\"[ ]*OpenSSL[ ]*//' -e 's/[ ].*//'`
                     AC_SUBST([OPENSSL_VERSION])
 
                     dnl Decompose required version string and calculate numerical representation


### PR DESCRIPTION
This permits better detection of OpenSSL 1.x (doesn't handle the newest 3.x).
