### PR TITLE
Remove register keyword for C++17 compatibility

### DIFF
--- a/src/AS_DCP_AES.cpp
+++ b/src/AS_DCP_AES.cpp
@@ -219,7 +219,7 @@ ASDCP::AESDecContext::DecryptBlock(const byte_t* ct_buf, byte_t* pt_buf, ui32_t 
   if ( m_Context.empty() )
     return  RESULT_INIT;
 
-  register h__AESContext* Ctx = m_Context;
+  h__AESContext* Ctx = m_Context;
 
   const byte_t* in_p = ct_buf;
   byte_t* out_p = pt_buf;

--- a/src/KM_fileio.cpp
+++ b/src/KM_fileio.cpp
@@ -745,7 +745,7 @@ Kumu::Result_t
 Kumu::FileWriter::Writev(const byte_t* buf, ui32_t buf_len)
 {
   assert( ! m_IOVec.empty() );
-  register h__iovec* iov = m_IOVec;
+  h__iovec* iov = m_IOVec;
   KM_TEST_NULL_L(buf);
 
   if ( iov->m_Count >= IOVecMaxEntries )
@@ -1009,7 +1009,7 @@ Kumu::Result_t
 Kumu::FileWriter::Writev(ui32_t* bytes_written)
 {
   assert( ! m_IOVec.empty() );
-  register h__iovec* iov = m_IOVec;
+  h__iovec* iov = m_IOVec;
   ui32_t tmp_int;
 
   if ( bytes_written == 0 )
@@ -1023,7 +1023,7 @@ Kumu::FileWriter::Writev(ui32_t* bytes_written)
   Result_t result = Kumu::RESULT_OK;
 
   // AFAIK, there is no writev() equivalent in the win32 API
-  for ( register int i = 0; i < iov->m_Count; i++ )
+  for ( int i = 0; i < iov->m_Count; i++ )
     {
       ui32_t tmp_count = 0;
       BOOL wr_result = ::WriteFile(m_Handle,
@@ -1193,7 +1193,7 @@ Kumu::Result_t
 Kumu::FileWriter::Writev(ui32_t* bytes_written)
 {
   assert( ! m_IOVec.empty() );
-  register h__iovec* iov = m_IOVec;
+  h__iovec* iov = m_IOVec;
   ui32_t tmp_int;
 
   if ( bytes_written == 0 )

--- a/src/KM_util.cpp
+++ b/src/KM_util.cpp
@@ -358,8 +358,8 @@ Kumu::base64encode(const byte_t* buf, ui32_t buf_len, char* strbuf, ui32_t strbu
 i32_t
 Kumu::base64decode(const char* str, byte_t* buf, ui32_t buf_len, ui32_t* char_count)
 {
-  register byte_t c = 0, d = 0;
-  register ui32_t phase = 0, i = 0;
+  byte_t c = 0, d = 0;
+  ui32_t phase = 0, i = 0;
 
   if ( str == 0 || buf == 0 || char_count == 0 )
     return -1;

--- a/src/MPEG.cpp
+++ b/src/MPEG.cpp
@@ -151,13 +151,13 @@ ASDCP::MPEG2::VESParser::Parse(const byte_t* buf, ui32_t buf_len)
   ASDCP_TEST_NULL(m_Delegate);
 
   Result_t result = RESULT_OK;
-  register const byte_t* end_p = buf + buf_len;
-  register const byte_t* run_pos = buf; // track runs of uninteresting data using a position and count
-  register ui32_t  run_len = 0;
+  const byte_t* end_p = buf + buf_len;
+  const byte_t* run_pos = buf; // track runs of uninteresting data using a position and count
+  ui32_t  run_len = 0;
 
   // search for MPEG2 headers
   // copy interesting data to a buffer and pass to delegate for processing
-  for ( register const byte_t* p = buf; p < end_p; p++ )
+  for ( const byte_t* p = buf; p < end_p; p++ )
     {
       if ( m_State->Test_IN_HEADER() )
 	{


### PR DESCRIPTION
The register keyword has long been deprecated in C++ and is now invalid. This commit removes the keyword so that builds in C++17 complete without error.

Note that this doesn't change the build settings - just removes the use of "register".

I tested locally by adding these lines to CMakeLists.txt:

```
set(CMAKE_CXX_STANDARD 17)
set(CMAKE_CXX_STANDARD_REQUIRED ON)
```
