### PR TITLE
CMake: fix linking on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0)
 
 project(asdcplib)
 


### PR DESCRIPTION
Specifying `cmake_minimum_required(VERSION 2.8.12)` triggers `cmake` to fall-back to old behaviour wrt `@rpath` on my recent macOS system - which in turn breaks linking. Build succeeds, but the binaries die with `dyld`'s `Library not loaded` error.

https://cmake.org/cmake/help/latest/policy/CMP0042.html has a comment on `cmake`'s changed default wrt `MACOSX_RPATH` in versions >= 3.0.

`cmake_minimum_required(VERSION 3.0)` fixes the linking for me.

If changing `cmake_minimum_required` breaks stuff for people there is another option:
Instead add `set(CMAKE_MACOSX_RPATH ON)` early in `CMakeLists.txt`.

My `cmake` version from a fresh `brew install cmake` is 3.28.1. `make` from `xcode-select --install` is 3.81. macOS is 14.2.1.

Superficial understanding of the involved mechanisms, so this may well be a local issue.