### PR TITLE
Remove a broken, unused template class

### DIFF
--- a/src/MXF.h
+++ b/src/MXF.h
@@ -263,30 +263,6 @@ namespace ASDCP
 	  const PropertyType& const_get() const { return m_property; }
 	};
 
-      // wrapper object manages optional properties
-      template <class PropertyType>
-	class optional_container_property
-	{
-	  PropertyType m_property;
-
-	public:
-	  optional_container_property() {}
-	optional_container_property(const PropertyType& value) : m_property(value) {}
-	  const optional_container_property<PropertyType>& operator=(const PropertyType& rhs) {
-	    this->Copy(rhs.m_property);
-	    return *this;
-	  }
-
-	  bool operator==(const PropertyType& rhs) const { return this->m_property == rhs; }
-	  bool operator==(const optional_property<PropertyType>& rhs) const { return this->m_property == rhs.m_property; }
-	  operator PropertyType&() { return this->m_property; }
-	  void set(const PropertyType& rhs) { this->m_property = rhs; }
-	  void reset(const PropertyType& rhs) { this->clear(); }
-	  bool empty() const { return ! this->m_property.HasValue(); }
-	  PropertyType& get() { return m_property; }
-	  const PropertyType& const_get() const { return m_property; }
-	};
-
       // base class of all metadata objects
       //
       class InterchangeObject : public ASDCP::KLVPacket


### PR DESCRIPTION
Since Clang changes
https://github.com/llvm/llvm-project/pull/84050 and https://github.com/llvm/llvm-project/pull/90152 (upcoming in Clang 19.x), Clang will diagnose member accesses before instantiating C++ templates.

Within the optional_container_property template, this causes errors for the calls to this->Copy() and this->clear(), as there are no corresponding methods within that template class, errors like these:

    asdcplib/src/MXF.h:276:12: error: no member named 'Copy' in 'optional_container_property<PropertyType>'
      276 |             this->Copy(rhs.m_property);
          |             ~~~~  ^
    asdcplib/src/MXF.h:284:48: error: no member named 'clear' in 'optional_container_property<PropertyType>'
      284 |           void reset(const PropertyType& rhs) { this->clear(); }
          |                                                 ~~~~  ^

This template is unused, and these faulty calls have been present since the class was added in 02915821cfb49cb6851086f5d991cee58328102b.

Simply remove the unused template class, to avoid these compiler errors.

This fixes https://github.com/cinecert/asdcplib/issues/136.