### PR TITLE
fix: handle odd-sized wav chunks

### DIFF
--- a/src/Wav.cpp
+++ b/src/Wav.cpp
@@ -157,7 +157,7 @@ ASDCP::Wav::SimpleWaveHeader::ReadFromBuffer(const byte_t* buf, ui32_t buf_len, 
   while ( p < end_p )
     {
       test_fcc = fourcc(p); p += 4;
-      ui32_t chunk_size = KM_i32_LE(Kumu::cp2i<ui32_t>(p)); p += sizeof(ui32_t);
+      ui32_t chunk_size = KM_i32_LE(Kumu::cp2i<ui32_t>(p) + (Kumu::cp2i<ui32_t>(p) % 2)); p += sizeof(ui32_t);
 
       if ( test_fcc == FCC_data )
 	{


### PR DESCRIPTION
Page 11 of [ye old WAV spec](https://www.mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/Docs/riffmci.pdf) states regarding `ckData` that `...If the chunk size is an odd number of
bytes, a pad byte with value zero is written after ckData. Word aligning
improves access speed (for chunks resident in memory) and maintains
compatibility with EA IFF. The ckSize value does not include the pad byte.`

This MR allows for the successful handling of odd-sized chunks found in WAV files that are input to asdcplib.
