### PR TITLE
Adds automatic buffer resizing capability 

### DIFF
--- a/src/h__Reader.cpp
+++ b/src/h__Reader.cpp
@@ -398,13 +398,23 @@ ASDCP::Read_EKLV_Packet(Kumu::IFileReader& File, const ASDCP::Dictionary& Dict,
     }
   else if ( Key.MatchIgnoreStream(EssenceUL) ) // ignore the stream number
     { // read plaintext frame
-       if ( FrameBuf.Capacity() < PacketLength )
-	{
-	  char intbuf[IntBufferLen];
-	  DefaultLogSink().Error("FrameBuf.Capacity: %u FrameLength: %s\n",
-				 FrameBuf.Capacity(), ui64sz(PacketLength, intbuf));
-	  return RESULT_SMALLBUF;
-	}
+      if ( FrameBuf.Capacity() < PacketLength )
+      {
+          Result_t resize_result = FrameBuf.Capacity((ui32_t)PacketLength);
+          
+          if (ASDCP_SUCCESS(resize_result))
+          {
+              DefaultLogSink().Warn("FrameBuf automatically resized to %u bytes\n", 
+                                   (ui32_t)PacketLength);
+          }
+          else
+          {
+              char intbuf[IntBufferLen];
+              DefaultLogSink().Error("FrameBuf.Capacity: %u FrameLength: %s (resize failed)\n",
+                                   FrameBuf.Capacity(), ui64sz(PacketLength, intbuf));
+              return RESULT_SMALLBUF;
+          }
+      }
 
       // read the data into the supplied buffer
       ui32_t read_count;


### PR DESCRIPTION
Adds automatic buffer resizing capability when reading frames where the buffer capacity is too small for the incoming packet length. Previously this would return a RESULT_SMALLBUF error, now it attempts to resize the buffer first.

### Changes
- Added automatic resizing of FrameBuf when capacity is insufficient
- Added warning log to notify when buffer is automatically resized
- Maintains original error handling if resize operation fails
- Uses existing Result_t error handling pattern

