### PR TITLE
Read only right frames out of a stereo MXF file

### DIFF
--- a/src/AS_DCP_JP2K.cpp
+++ b/src/AS_DCP_JP2K.cpp
@@ -945,7 +945,7 @@ public:
 	    if ( ASDCP_SUCCESS(result) )
 	      {
 		// skip over the companion SP_LEFT frame
-		Kumu::fpos_t new_pos = FilePosition + SMPTE_UL_LENGTH + Reader.KLLength() + Reader.Length();
+		Kumu::fpos_t new_pos = FilePosition + Reader.KLLength() + Reader.Length();
 		result = m_File->Seek(new_pos);
 	      }
 	  }


### PR DESCRIPTION
Reading only the right frames out of a JPEG2K Stereo MXF failed, because the calculated seek position seeks to the BER of the right frame, but the reader expects the position at the UL instead.

Corrected the seek position to the UL of the right frame.