### PR TITLE
Fix non-standard format specifiers

### DIFF
--- a/src/KM_util.h
+++ b/src/KM_util.h
@@ -103,11 +103,11 @@ namespace Kumu
   };
 #else
   struct i64Printer : public IntPrinter<i64_t, 32> {
-    i64Printer(i64_t value) : IntPrinter<i64_t, 32>("%qd", value) {}
+    i64Printer(i64_t value) : IntPrinter<i64_t, 32>("%lld", value) {}
   };
 
   struct ui64Printer : public IntPrinter<ui64_t, 32> {
-    ui64Printer(ui64_t value) : IntPrinter<ui64_t, 32>("%qu", value) {}
+    ui64Printer(ui64_t value) : IntPrinter<ui64_t, 32>("%llu", value) {}
   };
 #endif
 

--- a/src/MXF.cpp
+++ b/src/MXF.cpp
@@ -794,11 +794,11 @@ ASDCP::MXF::OP1aHeader::InitFromFile(const Kumu::IFileReader& Reader)
     }
   else if ( HeaderByteCount < 1024 )
     {
-      DefaultLogSink().Warn("Improbably small HeaderByteCount value: %qu\n", HeaderByteCount);
+      DefaultLogSink().Warn("Improbably small HeaderByteCount value: %llu\n", HeaderByteCount);
     }
   else if (HeaderByteCount > ( 4 * Kumu::Megabyte ) )
     {
-      DefaultLogSink().Warn("Improbably huge HeaderByteCount value: %qu\n", HeaderByteCount);
+      DefaultLogSink().Warn("Improbably huge HeaderByteCount value: %llu\n", HeaderByteCount);
     }
   
   result = m_HeaderData.Capacity(Kumu::xmin(4*Kumu::Megabyte, static_cast<ui32_t>(HeaderByteCount)));

--- a/src/klvwalk.cpp
+++ b/src/klvwalk.cpp
@@ -324,7 +324,7 @@ main(int argc, const char** argv)
 
 		  if ( plain_part.ThisPartition != i->ByteOffset )
 		    {
-		      DefaultLogSink().Error("ThisPartition value error: wanted=%qu, got=%qu\n",
+		      DefaultLogSink().Error("ThisPartition value error: wanted=%llu, got=%llu\n",
 					     plain_part.ThisPartition, i->ByteOffset);
 		    }
 


### PR DESCRIPTION
For printing long long signed and long long unsigned. 

This issue arose from using numpy or matplotlib in conjuction with printing the filesize of large files. "%qd" and "%qu" are non-standard and non portable specifiers that can produce garbage when something like numpy is imported and changes the dynamic linking environment.