### PR TITLE
Update CMakeLists.txt cmake_minimum_required=3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(asdcplib)
 


### PR DESCRIPTION
Fixes building on macOS Tahoe 26.