### PR TITLE
Fix compatibility with CMake 4.2.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(asdcplib)
 


### PR DESCRIPTION
Updated CMakeLists.txt cmake_minimum_required to VERSION 3.5 in order to satisfy current CMake requirements.